### PR TITLE
fix: Lengthen the timeout for the prod backend

### DIFF
--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -10,4 +10,4 @@ RUN poetry install
 
 EXPOSE 80
 
-CMD exec poetry run uvicorn --timeout-keep-alive 75 zeno_backend.server:get_server --reload --host 0.0.0.0 --port 80
+CMD exec poetry run uvicorn zeno_backend.server:get_server --reload --host 0.0.0.0 --port 80 --timeout-keep-alive 75

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -10,4 +10,4 @@ RUN poetry install
 
 EXPOSE 80
 
-CMD exec poetry run uvicorn zeno_backend.server:get_server --reload --host 0.0.0.0 --port 80 --timeout-keep-alive 75
+CMD exec poetry run uvicorn --timeout-keep-alive 75 zeno_backend.server:get_server --reload --host 0.0.0.0 --port 80

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -10,4 +10,4 @@ RUN poetry install
 
 EXPOSE 80
 
-CMD exec poetry run uvicorn zeno_backend.server:get_server --reload --host 0.0.0.0 --port 80 --timeout-keep-alive 75
+CMD exec poetry run uvicorn zeno_backend.server:get_server --reload --host 0.0.0.0 --port 80 --timeout-keep-alive 75 --workers 4

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -10,4 +10,4 @@ RUN poetry install
 
 EXPOSE 80
 
-CMD exec poetry run uvicorn zeno_backend.server:get_server --reload --host 0.0.0.0 --port 80
+CMD exec poetry run uvicorn zeno_backend.server:get_server --reload --host 0.0.0.0 --port 80 --timeout-keep-alive 75


### PR DESCRIPTION
# Description

This PR lengthens the timeout for the prod backend from the default 5 seconds to 75 seconds. 75 seconds is chosen because it is longer than 60 seconds, which is a default that we're using in the application load balancer. See below for the recommendation for AWS.

In addition, it increases the number of workers for uvicorn to 4, because the "ping" requests will fail while doing longer requests on another thread if we only have 1 worker. This causes the worker to be killed by the load balancer, because the load balancer thinks the process is unhealthy.

# References

- https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html
- Part of https://linear.app/zenoml/issue/ZEN-148/bug-502-error-and-ensuing-json-decoding-error-when-uploading-large

# Blocked by

- NA

