### PR TITLE
fix: fix line chart without metric selected

### DIFF
--- a/frontend/src/lib/components/chart/chart-page/encoding/Encoding.svelte
+++ b/frontend/src/lib/components/chart/chart-page/encoding/Encoding.svelte
@@ -20,7 +20,7 @@
 </script>
 
 <div class="mb-20">
-	<h4 class="border-b-2 border-grey-light mb-2 pb-1">Chart Type</h4>
+	<h4 class="border-b-2 border-grey-light mb-2 pb-1">Encoding</h4>
 	<div id="flex flex-col">
 		<svelte:component this={encodingMap[chart.type]} bind:chart />
 	</div>

--- a/frontend/src/lib/components/chart/chart-types/line-chart/LineChart.svelte
+++ b/frontend/src/lib/components/chart/chart-types/line-chart/LineChart.svelte
@@ -15,6 +15,8 @@
 		const metric = metrics.find((m) => m.id === parameters.metric);
 		if (metric) {
 			spec = generateSpec(parameters, metric.name, height, width);
+		} else {
+			spec = generateSpec(parameters, 'slice size', height, width);
 		}
 	});
 </script>


### PR DESCRIPTION
# Description

The line chart did not handle the case with the slice size metric correctly. This has now been fixed.
