### PR TITLE
fix: cast data column to string always

### DIFF
--- a/backend/zeno_backend/database/insert.py
+++ b/backend/zeno_backend/database/insert.py
@@ -196,6 +196,9 @@ def dataset(
         )
     )
 
+    # To prevent upload errors, convert data column to string.
+    data_frame["data"] = data_frame["data"].astype(str)
+
     # Connect to the db engine using SQLAlchemy and write the data to a table.
     config = config_db()
     engine = create_engine(


### PR DESCRIPTION
# Description

When the data column did contain non-string data (e.g. arrays), the SQL alchemy insert was failing. Since the data column can be narrowed by the instance view in all cases, we can just store strings and extract information in the instance view.

fix ZEN-153
fix ZEN-147