### PR TITLE
fix: make encodings reload on chart type change

### DIFF
--- a/frontend/src/lib/components/chart/chart-page/view-selection/ChartElement.svelte
+++ b/frontend/src/lib/components/chart/chart-page/view-selection/ChartElement.svelte
@@ -9,7 +9,7 @@
 	import TableIcon from './chart-icons/TableIcon.svelte';
 
 	export let chart: Chart;
-	export let updateChart: (chartType: ChartType) => void;
+	export let updateChartType: (chartType: ChartType) => void;
 	export let type: ChartType;
 
 	const iconMap: Record<string, ComponentType> = {
@@ -37,7 +37,7 @@
 		? 'bg-primary-light'
 		: ''}"
 	on:keydown={() => ({})}
-	on:click={() => updateChart(type)}
+	on:click={() => updateChartType(type)}
 >
 	<svelte:component this={iconMap[type]} />
 	<h4 class="mt-1">{titleMap[type]}</h4>

--- a/frontend/src/lib/components/chart/chart-page/view-selection/ViewSelection.svelte
+++ b/frontend/src/lib/components/chart/chart-page/view-selection/ViewSelection.svelte
@@ -4,10 +4,12 @@
 	import ChartElement from './ChartElement.svelte';
 
 	export let chart: Chart;
+	export let unique: unknown;
 
-	async function updateChart(chartType: ChartType) {
+	async function updateChartType(chartType: ChartType) {
 		if (chart.type !== chartType) {
 			chart = chartDefaults(chart.name, chart.id, chart.projectUuid, chartType);
+			unique = {};
 		}
 	}
 </script>
@@ -15,11 +17,11 @@
 <div class="mb-5">
 	<h4 class="border-b-2 border-grey-light mb-2 pb-1">Chart Type</h4>
 	<div class="flex flex-wrap justify-between">
-		<ChartElement {chart} {updateChart} type={ChartType.BAR} />
-		<ChartElement {chart} {updateChart} type={ChartType.LINE} />
-		<ChartElement {chart} {updateChart} type={ChartType.TABLE} />
-		<ChartElement {chart} {updateChart} type={ChartType.BEESWARM} />
-		<ChartElement {chart} {updateChart} type={ChartType.RADAR} />
-		<ChartElement {chart} {updateChart} type={ChartType.HEATMAP} />
+		<ChartElement {chart} {updateChartType} type={ChartType.BAR} />
+		<ChartElement {chart} {updateChartType} type={ChartType.LINE} />
+		<ChartElement {chart} {updateChartType} type={ChartType.TABLE} />
+		<ChartElement {chart} {updateChartType} type={ChartType.BEESWARM} />
+		<ChartElement {chart} {updateChartType} type={ChartType.RADAR} />
+		<ChartElement {chart} {updateChartType} type={ChartType.HEATMAP} />
 	</div>
 </div>

--- a/frontend/src/routes/(app)/project/[owner]/[project]/chart/[chartIndex=integer]/+page.svelte
+++ b/frontend/src/routes/(app)/project/[owner]/[project]/chart/[chartIndex=integer]/+page.svelte
@@ -17,6 +17,7 @@
 	let isChartEdit: boolean | undefined;
 	let chart = data.chart;
 	let chartData: { table: Record<string, unknown> } | undefined;
+	let unique = {};
 
 	$: chartData = data.chartData;
 	$: updateEditUrl(isChartEdit);
@@ -51,8 +52,16 @@
 			class="border-r border-r-grey-lighter h-full pb-20 px-5 overflow-y-auto shrink-0 bg-yellowish-light w-[380px]"
 		>
 			<EditHeader bind:isChartEdit bind:chart />
-			<ViewSelection bind:chart />
-			<Encoding bind:chart />
+			<ViewSelection bind:chart bind:unique />
+			<!--
+				This is a hack to force the component to rerender on chart type change as the selections otherwise don't update.
+				If svelecte ever resolves this issue, this hack can be removed and we can listen to events on svelecte.
+				https://github.com/mskocik/svelecte/issues/200.
+				A detailed description of this problem is in: https://github.com/zeno-ml/zeno-hub/pull/235.
+			-->
+			{#key unique}
+				<Encoding bind:chart />
+			{/key}
 		</div>
 	{:else}
 		<ViewHeader bind:isChartEdit />


### PR DESCRIPTION
I tried a bunch of stuff to make encodings change on chart type change, but this is a bit problematic. Hence, I had to implement a hack to force the encoding component to re-render. The problem is the following:

Svelecte can only be used with dndzone when using bind:value, not with on:change, as on:change does not get triggered on reordering on elements with dndzone. However, we can't bind:value always because otherwise we have an infinite loop (value change leads to a dispatch so we can change the chart which leads to a value change).