### PR TITLE
fix: word breaks in reports

### DIFF
--- a/frontend/src/lib/components/general/Markdown.svelte
+++ b/frontend/src/lib/components/general/Markdown.svelte
@@ -2,9 +2,7 @@
 	export let renderedText: string;
 </script>
 
-<article
-	class="prose break-all [&_a]:break-all [&_p]:break-all [&_p]:whitespace-pre-wrap max-w-none"
->
+<article class="prose [&_a]:break-word [&_p]:whitespace-pre-wrap max-w-none">
 	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 	{@html renderedText}
 </article>


### PR DESCRIPTION
# Description
words in reports were breaking at end of line