### PR TITLE
fix: reenable sharing even if project is public already

### DIFF
--- a/frontend/src/lib/components/popups/ProjectPopup.svelte
+++ b/frontend/src/lib/components/popups/ProjectPopup.svelte
@@ -114,7 +114,7 @@
 				/>
 			</div>
 			<!--Visibility Settings-->
-			{#if !config.public && userRequest}
+			{#if userRequest}
 				{#await userRequest then currentUsers}
 					<div class="mb-5 flex flex-col mt-12" transition:fade>
 						<h3 class="text-lg mb-2">Viewers</h3>
@@ -193,7 +193,7 @@
 					</div>
 				{/await}
 			{/if}
-			{#if !config.public && organizationRequest}
+			{#if organizationRequest}
 				{#await organizationRequest then currentOrgs}
 					{#await ZenoService.getOrganizationNames() then oragnizationNames}
 						{@const availableOrgs = oragnizationNames.filter(

--- a/frontend/src/lib/components/popups/ReportPopup.svelte
+++ b/frontend/src/lib/components/popups/ReportPopup.svelte
@@ -92,7 +92,7 @@
 				style="width: 100%"
 			/>
 		</div>
-		{#if !reportConfig.public && userRequest}
+		{#if userRequest}
 			{#await userRequest then currentUsers}
 				<div class="mb-5 flex flex-col" transition:fade>
 					<h3 class="text-lg mb-2">Viewers</h3>
@@ -169,7 +169,7 @@
 				</div>
 			{/await}
 		{/if}
-		{#if !reportConfig.public && organizationRequest}
+		{#if organizationRequest}
 			{#await organizationRequest then currentOrgs}
 				<div class="mb-5 flex flex-col" transition:fade>
 					<h3 class="text-lg mb-2">Organizations</h3>


### PR DESCRIPTION
# Description

If we don't allow this, there is no way for people to see these projects on their home-pages.