### PR TITLE
fix: move slice header up if there is no model in a project

### DIFF
--- a/frontend/src/lib/components/metadata/MetadataPanel.svelte
+++ b/frontend/src/lib/components/metadata/MetadataPanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { collapseHeader } from '$lib/stores';
+	import { collapseHeader, models } from '$lib/stores';
 	import Histograms from './Histograms.svelte';
 	import HistogramsHeader from './HistogramsHeader.svelte';
 	import MetadataHeader from './MetadataHeader.svelte';
@@ -14,7 +14,9 @@
 		? 'hide-sidebar'
 		: 'show-sidebar'}"
 >
-	<MetadataHeader />
+	{#if $models.length > 0}
+		<MetadataHeader />
+	{/if}
 	<Slices />
 	<Tags />
 	{#if !compare}

--- a/frontend/src/lib/components/metadata/SliceHeader.svelte
+++ b/frontend/src/lib/components/metadata/SliceHeader.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import { project, selectionIds, selectionPredicates, selections } from '$lib/stores';
+	import { models, project, selectionIds, selectionPredicates, selections } from '$lib/stores';
 	import {
 		mdiCreation,
 		mdiCreationOutline,
@@ -29,7 +29,11 @@
 {#if showNewFolder}
 	<FolderPopup on:close={() => (showNewFolder = false)} />
 {/if}
-<div class="sticky top-14 bg-yellowish-light flex items-center justify-between z-10 min-h-[40px]">
+<div
+	class="sticky {$models.length > 0
+		? 'top-14'
+		: '-top-5'} bg-yellowish-light flex items-center justify-between z-10 min-h-[40px]"
+>
 	<div class="flex items-center justify-between">
 		<h4>Slices</h4>
 		<div


### PR DESCRIPTION
# Description

Before:
![image](https://github.com/zeno-ml/zeno-hub/assets/5690524/17730048-a61d-4861-bb47-dad3c5f2a4e7)

Now:
<img width="383" alt="image" src="https://github.com/zeno-ml/zeno-hub/assets/5690524/8c511dc3-b209-488a-a64c-cc5df6379d2c">

fix ZEN-215
