### PR TITLE
feat: add option to add slices for all values of a nominal column

### DIFF
--- a/backend/zeno_backend/database/delete.py
+++ b/backend/zeno_backend/database/delete.py
@@ -61,19 +61,29 @@ def report(report_id: int):
     )
 
 
-def folder(folder: Folder):
+async def folder(folder: Folder, delete_slices: bool):
     """Deletes a folder from an existing project.
 
     Args:
         folder (Folder): the folder to be deleted.
+        delete_slices (bool): whether to delete the slices in the folder as well.
     """
-    db = Database()
-    db.connect_execute(
-        "DELETE FROM folders WHERE id = %s;",
-        [
-            folder.id,
-        ],
-    )
+    async with db_pool.connection() as conn:
+        async with conn.cursor() as cur:
+            if delete_slices:
+                await cur.execute(
+                    "DELETE FROM slices WHERE folder_id = %s;",
+                    [
+                        folder.id,
+                    ],
+                )
+            await cur.execute(
+                "DELETE FROM folders WHERE id = %s;",
+                [
+                    folder.id,
+                ],
+            )
+            await conn.commit()
 
 
 def slice(req: Slice):

--- a/backend/zeno_backend/server.py
+++ b/backend/zeno_backend/server.py
@@ -674,6 +674,21 @@ def get_server() -> FastAPI:
         return id
 
     @api_app.post(
+        "/all-slices/{project}",
+        response_model=list[int],
+        tags=["zeno"],
+        dependencies=[Depends(auth)],
+    )
+    async def add_all_slices(project: str, req: ZenoColumn):
+        ids = await insert.all_slices_for_column(project, req)
+        if ids is None:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to insert slices",
+            )
+        return ids
+
+    @api_app.post(
         "/chart/{project}",
         response_model=int,
         tags=["zeno"],

--- a/backend/zeno_backend/server.py
+++ b/backend/zeno_backend/server.py
@@ -680,7 +680,13 @@ def get_server() -> FastAPI:
         dependencies=[Depends(auth)],
     )
     async def add_all_slices(project: str, req: ZenoColumn):
-        ids = await insert.all_slices_for_column(project, req)
+        try:
+            ids = await insert.all_slices_for_column(project, req)
+        except Exception as exc:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=str(exc),
+            ) from exc
         if ids is None:
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -878,8 +884,8 @@ def get_server() -> FastAPI:
         delete.chart(chart)
 
     @api_app.delete("/folder", tags=["zeno"], dependencies=[Depends(auth)])
-    def delete_folder(folder: Folder):
-        delete.folder(folder)
+    async def delete_folder(folder: Folder, delete_slices: bool = False):
+        await delete.folder(folder, delete_slices)
 
     @api_app.delete("/tag", tags=["zeno"], dependencies=[Depends(auth)])
     def delete_tag(tag: Tag):

--- a/frontend/src/lib/components/popups/Confirm.svelte
+++ b/frontend/src/lib/components/popups/Confirm.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import Button from '@smui/button/src/Button.svelte';
+	import Paper, { Content } from '@smui/paper';
+	import { createEventDispatcher } from 'svelte';
+	import { fade } from 'svelte/transition';
+
+	export let message: string;
+	export let confirmText = 'Confirm';
+	export let cancelText = 'Cancel';
+
+	const dispatch = createEventDispatcher();
+
+	let paperHeight;
+</script>
+
+<div
+	class="absolute inset-0 z-20 flex justify-center items-baseline p-12 bg-grey bg-opacity-60"
+	transition:fade={{ duration: 200 }}
+	bind:clientHeight={paperHeight}
+>
+	<Paper class="pt-3 flex flex-col" elevation={7}>
+		<Content>
+			<span>{message}</span>
+			<slot />
+			<div class="flex flex-row-reverse">
+				<Button style="margin-right: 10px" variant="outlined" on:click={() => dispatch('confirm')}>
+					{confirmText}
+				</Button>
+				<Button style="margin-right: 10px" variant="outlined" on:click={() => dispatch('cancel')}>
+					{cancelText}
+				</Button>
+			</div>
+		</Content>
+	</Paper>
+</div>

--- a/frontend/src/lib/zenoapi/models/Body_upload_dataset_schema.ts
+++ b/frontend/src/lib/zenoapi/models/Body_upload_dataset_schema.ts
@@ -7,6 +7,6 @@ export type Body_upload_dataset_schema = {
 	project_uuid: any;
 	id_column: any;
 	data_column: any;
-	label_column: any;
+	label_column?: any;
 	file: Blob;
 };

--- a/frontend/src/lib/zenoapi/models/User.ts
+++ b/frontend/src/lib/zenoapi/models/User.ts
@@ -9,10 +9,12 @@
  * Attributes:
  * id (int): ID of the user.
  * name (str): name of the user.
+ * cognito_id (str | None): Cognito ID of the user. Default None.
  * admin (bool | None): whether the user is an admin. Default None.
  */
 export type User = {
 	id: number;
 	name: string;
+	cognitoId?: string | null;
 	admin?: boolean | null;
 };

--- a/frontend/src/lib/zenoapi/services/ZenoService.ts
+++ b/frontend/src/lib/zenoapi/services/ZenoService.ts
@@ -998,6 +998,31 @@ export class ZenoService {
 	}
 
 	/**
+	 * Add All Slices
+	 * @param project
+	 * @param requestBody
+	 * @returns number Successful Response
+	 * @throws ApiError
+	 */
+	public static addAllSlices(
+		project: string,
+		requestBody: ZenoColumn
+	): CancelablePromise<Array<number>> {
+		return __request(OpenAPI, {
+			method: 'POST',
+			url: '/all-slices/{project}',
+			path: {
+				project: project
+			},
+			body: requestBody,
+			mediaType: 'application/json',
+			errors: {
+				422: `Validation Error`
+			}
+		});
+	}
+
+	/**
 	 * Add Chart
 	 * @param project
 	 * @param requestBody

--- a/frontend/src/lib/zenoapi/services/ZenoService.ts
+++ b/frontend/src/lib/zenoapi/services/ZenoService.ts
@@ -1706,13 +1706,20 @@ export class ZenoService {
 	/**
 	 * Delete Folder
 	 * @param requestBody
+	 * @param deleteSlices
 	 * @returns any Successful Response
 	 * @throws ApiError
 	 */
-	public static deleteFolder(requestBody: Folder): CancelablePromise<any> {
+	public static deleteFolder(
+		requestBody: Folder,
+		deleteSlices: boolean = false
+	): CancelablePromise<any> {
 		return __request(OpenAPI, {
 			method: 'DELETE',
 			url: '/folder',
+			query: {
+				delete_slices: deleteSlices
+			},
 			body: requestBody,
 			mediaType: 'application/json',
 			errors: {


### PR DESCRIPTION
# Description

The slice popup changes if a user selects only a nominal column without entering anything else as follows:
<img width="768" alt="image" src="https://github.com/zeno-ml/zeno-hub/assets/5690524/0ceff78b-697a-4b78-a8f2-9c2979771aa4">

After creation, slices will look as follows:
<img width="343" alt="image" src="https://github.com/zeno-ml/zeno-hub/assets/5690524/90fe1c2d-a732-4cec-b16e-4fd762e8fffc">

fix ZEN-214
