### PR TITLE
fix: fix return value for zero mean result

### DIFF
--- a/backend/zeno_backend/processing/metrics/mean.py
+++ b/backend/zeno_backend/processing/metrics/mean.py
@@ -80,7 +80,9 @@ def mean(
         else:
             res = db.cur.fetchone()
 
-        if res:
-            return GroupMetric(metric=float(res[1]) if res[1] else None, size=res[0])
+        if res is not None:
+            return GroupMetric(
+                metric=float(res[1]) if res[1] is not None else None, size=res[0]
+            )
         else:
             return GroupMetric(metric=None, size=0)


### PR DESCRIPTION
When the result of a mean metric calculation was zero, we were returning None. This has been change to correctly reflect the metric value.

fix ZEN-229