### PR TITLE
fix: make sure charts always fit into report width

### DIFF
--- a/frontend/src/lib/components/chart/chart-types/bar-chart/vegaSpec-bar.ts
+++ b/frontend/src/lib/components/chart/chart-types/bar-chart/vegaSpec-bar.ts
@@ -14,9 +14,9 @@ export default function generateSpec(
 		$schema: 'https://vega.github.io/schema/vega-lite/v5.json',
 		description: 'A simple bar chart with embedded data.',
 		random_id: Date.now(), // used to force re-rendering of the chart
-		autosize: 'pad',
 		height: height,
 		width: width,
+		autosize: 'fit',
 		data: {
 			name: 'table'
 		},

--- a/frontend/src/lib/components/chart/chart-types/beeswarm-chart/vegaSpec-beeswarm.ts
+++ b/frontend/src/lib/components/chart/chart-types/beeswarm-chart/vegaSpec-beeswarm.ts
@@ -16,8 +16,7 @@ export default function generateSpec(
 		height: 100,
 		random_id: Date.now(), // used to force re-rendering of the chart
 		padding: { left: 5, right: 5, top: 0, bottom: 20 },
-		autosize: 'pad',
-
+		autosize: 'fit',
 		signals: [
 			{ name: 'cx', update: 'width / 2' },
 			{ name: 'cy', update: 'height / 2' },

--- a/frontend/src/lib/components/chart/chart-types/line-chart/vegaSpec-line.ts
+++ b/frontend/src/lib/components/chart/chart-types/line-chart/vegaSpec-line.ts
@@ -16,6 +16,7 @@ export default function generateSpec(
 		random_id: Date.now(), // used to force re-rendering of the chart
 		width: width,
 		height: height,
+		autosize: 'fit',
 		padding: { top: 20 },
 		data: {
 			name: 'table'

--- a/frontend/src/lib/components/chart/chart-types/radar-chart/vegaSpec-radar.ts
+++ b/frontend/src/lib/components/chart/chart-types/radar-chart/vegaSpec-radar.ts
@@ -10,7 +10,7 @@ export default function generateSpec(
 		$schema: 'https://vega.github.io/schema/vega/v5.json',
 		description: 'A radar chart example, showing multiple dimensions in a radial layout.',
 		random_id: Date.now(), // used to force re-rendering of the chart
-		autosize: { type: 'none', contains: 'padding' },
+		autosize: { type: 'fit', contains: 'padding' },
 		padding: { left: 80, right: 200, top: 60, bottom: 50 },
 		width: width,
 		height: height,

--- a/frontend/src/lib/components/report/Element.svelte
+++ b/frontend/src/lib/components/report/Element.svelte
@@ -25,7 +25,7 @@
 			<TextElement {element} />
 		{:else if element.type === ReportElementType.CHART}
 			{#await chartOptions then options}
-				<ChartElement chart={options.filter((c) => c.id === chartId)[0]} width={width - 200} />
+				<ChartElement chart={options.filter((c) => c.id === chartId)[0]} {width} />
 			{/await}
 		{:else if element.type === ReportElementType.SLICE}
 			<SliceElement {element} />

--- a/frontend/src/lib/components/report/elements/ChartElement.svelte
+++ b/frontend/src/lib/components/report/elements/ChartElement.svelte
@@ -1,23 +1,9 @@
 <script lang="ts">
-	import BarChart from '$lib/components/chart/chart-types/bar-chart/BarChart.svelte';
-	import BeeswarmChart from '$lib/components/chart/chart-types/beeswarm-chart/BeeswarmChart.svelte';
-	import HeatMap from '$lib/components/chart/chart-types/heatmap-chart/HeatMap.svelte';
-	import LineChart from '$lib/components/chart/chart-types/line-chart/LineChart.svelte';
-	import RadarChart from '$lib/components/chart/chart-types/radar-chart/RadarChart.svelte';
-	import Table from '$lib/components/chart/chart-types/table/Table.svelte';
+	import { chartMap } from '$lib/util/charts';
 	import { ChartType, type Chart, type ZenoService } from '$lib/zenoapi';
-	import { getContext, type ComponentType } from 'svelte';
+	import { getContext } from 'svelte';
 
 	const zenoClient = getContext('zenoClient') as ZenoService;
-
-	const chartMap: Record<string, ComponentType> = {
-		[ChartType.BAR]: BarChart,
-		[ChartType.LINE]: LineChart,
-		[ChartType.TABLE]: Table,
-		[ChartType.BEESWARM]: BeeswarmChart,
-		[ChartType.RADAR]: RadarChart,
-		[ChartType.HEATMAP]: HeatMap
-	};
 
 	export let chart: Chart;
 	export let width: number;
@@ -36,7 +22,7 @@
 				{chart}
 				{width}
 				data={JSON.parse(data)}
-				height={chart.type == ChartType.RADAR ? 550 : 300}
+				height={chart.type == ChartType.RADAR ? 600 : 400}
 			/>
 		</div>
 	</div>

--- a/frontend/src/routes/(app)/project/[owner]/[project]/chart/[chartIndex=integer]/+page.svelte
+++ b/frontend/src/routes/(app)/project/[owner]/[project]/chart/[chartIndex=integer]/+page.svelte
@@ -71,7 +71,7 @@
 	{#if chartData}
 		<div class={`overflow-auto flex flex-col pl-2 h-full`}>
 			<ChartContainer chartName={chart.name}>
-				<svelte:component this={chartMap[chart.type]} {chart} data={chartData} width={700} />
+				<svelte:component this={chartMap[chart.type]} {chart} data={chartData} width={900} />
 			</ChartContainer>
 		</div>
 	{/if}


### PR DESCRIPTION
# Description

Using the [autosize function](https://vega.github.io/vega-lite/docs/size.html#autosize) of Vega.

fix ZEN-239