### PR TITLE
feat: fix report element edit w/o project

### DIFF
--- a/frontend/src/lib/components/report/AddElementButton.svelte
+++ b/frontend/src/lib/components/report/AddElementButton.svelte
@@ -12,7 +12,7 @@
 	on:click={() => addElement(position)}
 >
 	<div
-		class="justify-center items-center h-1 w-full bg-primary-dark
+		class="justify-center items-center h-0.5 w-full bg-primary-dark
         {!alwaysShow ? 'group-hover:flex hidden' : 'flex'}
     "
 	>

--- a/frontend/src/routes/(app)/report/[owner]/[report]/+page.svelte
+++ b/frontend/src/routes/(app)/report/[owner]/[report]/+page.svelte
@@ -84,7 +84,7 @@
 			</h1>
 		</div>
 		<h5 class="mt-4 ml-1 text-lg">Author: {data.report.ownerName}</h5>
-		<hr class="mt-4 bg-grey-dark" />
+		<hr class="mt-4 text-grey-light" />
 
 		{#if data.report.editor}
 			<p class="mt-4 mb-2">Associated Projects</p>
@@ -99,7 +99,7 @@
 					options={projects}
 				/>
 			{/await}
-			<hr class="mt-4 mb-4 bg-grey-dark" />
+			<hr class="mt-4 mb-4 text-grey-light" />
 			<AddElementButton
 				position={0}
 				{addElement}


### PR DESCRIPTION
# Description
Fixes reports without projects showing. Also updates styles as discussed:

<img width="1434" alt="Screenshot 2023-10-24 at 17 02 59" src="https://github.com/zeno-ml/zeno-hub/assets/4563691/311289d6-1075-4ebf-9b2f-af9e3c1028c6">
