### PR TITLE
fix: histogram calc and table view

### DIFF
--- a/backend/zeno_backend/processing/histogram_processing.py
+++ b/backend/zeno_backend/processing/histogram_processing.py
@@ -83,8 +83,12 @@ async def calculate_histogram_bucket(
                 # Replicate the numpy histogram binning, max of Sturges and FD
                 # https://numpy.org/doc/stable/reference/generated/numpy.histogram_bin_edges.html
                 buckets_sturges = 1 + math.ceil(math.log2(res[3]))
-                buckets_fd = math.ceil(2 * res[2] / res[3] ** (1 / 3))
-                buckets = max(buckets_sturges, buckets_fd)
+                buckets_fd_width = math.ceil(2 * res[2] / res[3] ** (1 / 3))
+                if buckets_fd_width == 0:
+                    buckets = buckets_sturges
+                else:
+                    buckets_fd = math.ceil((res[1] - res[0]) / buckets_fd_width)
+                    buckets = max(buckets_sturges, buckets_fd)
                 step = (res[1] - res[0]) / buckets
 
                 return [

--- a/frontend/src/lib/components/instances/TableView.svelte
+++ b/frontend/src/lib/components/instances/TableView.svelte
@@ -52,7 +52,9 @@
 	$: columnHeader = $columns.filter(
 		(c) =>
 			(c.model === undefined || c.model === null || c.model === $model) &&
-			c.columnType === ZenoColumnType.FEATURE
+			(c.columnType === ZenoColumnType.FEATURE ||
+				((c.columnType === ZenoColumnType.LABEL || c.columnType === ZenoColumnType.OUTPUT) &&
+					$project.view == ''))
 	);
 	$: start = currentPage * $rowsPerPage;
 	$: end = start + $rowsPerPage;
@@ -131,6 +133,7 @@
 				{#if $editTag !== undefined}
 					<th class="p-3 font-semibold font-grey">Included</th>
 				{/if}
+				<th class="p-3 font-semibold font-grey">ID</th>
 				{#if $project.view}
 					<th
 						class="p-3 font-semibold font-grey whitespace-nowrap"
@@ -173,6 +176,9 @@
 									<Checkbox bind:group={currentTagIds} value={String(tableContent[idColumn])} />
 								</td>
 							{/if}
+							<td class="p-3 border border-grey-lighter align-top">
+								{tableContent[idColumn]}
+							</td>
 							{#if $project.view}
 								<td class="p-3">
 									{#if instanceHidden}


### PR DESCRIPTION
# Description
* Apparently been calculating buckets for FD wrong the whole time - it returns the width of bins, not the count
* Always show ID column in table, and if in tabular view also show the label and output (which are shown in the instance view for normal data)