### PR TITLE
fix: various fixes

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -11,6 +11,9 @@ vite.config.ts.timestamp-*
 # Created by https://www.toptal.com/developers/gitignore/api/svelte,node
 # Edit at https://www.toptal.com/developers/gitignore?templates=svelte,node
 
+.yalc
+yalc.lock
+
 ### Node ###
 # Logs
 logs

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,7 +59,7 @@
 		"@auth/core": "^0.18.0",
 		"@auth/sveltekit": "^0.3.11",
 		"@mdi/js": "^7.3.67",
-		"@zeno-ml/zeno-instance-views": "^0.0.7",
+		"@zeno-ml/zeno-instance-views": "^0.0.8",
 		"amazon-cognito-identity-js": "^6.3.6",
 		"d3-array": "^3.2.4",
 		"d3-interpolate": "^3.0.1",

--- a/frontend/src/lib/components/instances/ComparisonView.svelte
+++ b/frontend/src/lib/components/instances/ComparisonView.svelte
@@ -175,7 +175,12 @@
 </script>
 
 <div class="w-full h-full overflow-auto" bind:this={instanceContainer}>
-	<table class="mt-2">
+	<table class="mt-2 w-full table-fixed">
+		<colgroup>
+			<col style="width: 45%;" />
+			<col style="width: 45%;" />
+			<col style="width: 10%;" />
+		</colgroup>
 		<thead
 			class="sticky border-b border-grey-lighter font-semibold top-0 left-0 text-left align-top bg-background z-10"
 		>

--- a/frontend/src/lib/components/instances/ListView.svelte
+++ b/frontend/src/lib/components/instances/ListView.svelte
@@ -97,7 +97,10 @@
 	}
 </script>
 
-<div class="overflow-y-auto flex flex-wrap content-start w-full h-full">
+<div
+	class="overflow-y-auto w-full h-full grid"
+	style="grid-template-columns: repeat(auto-fill, minmax(400px, 1fr))"
+>
 	{#await tablePromise then table}
 		{#if idColumn !== undefined}
 			{#each table as inst (inst[idColumn])}

--- a/frontend/src/lib/components/instances/ListView.svelte
+++ b/frontend/src/lib/components/instances/ListView.svelte
@@ -99,7 +99,7 @@
 
 <div
 	class="overflow-y-auto w-full h-full grid"
-	style="grid-template-columns: repeat(auto-fill, minmax(400px, 1fr))"
+	style="grid-template-columns: repeat(auto-fill, minmax(400px, 1fr)); grid-auto-rows: min-content;"
 >
 	{#await tablePromise then table}
 		{#if idColumn !== undefined}

--- a/frontend/src/lib/components/metadata/MetricRange.svelte
+++ b/frontend/src/lib/components/metadata/MetricRange.svelte
@@ -1,5 +1,20 @@
 <script lang="ts">
 	import { metric, metricRange, metrics } from '$lib/stores';
+
+	function updateRange(e: Event, i: number) {
+		const target = e.target as HTMLElement;
+
+		let val = parseFloat(target.innerText);
+		if (isNaN(val)) {
+			target.innerText = $metricRange[i].toFixed(2);
+			return;
+		}
+
+		metricRange.update((range) => {
+			range[i] = val;
+			return [...range];
+		});
+	}
 </script>
 
 {#if $metrics.length !== 0 && $metricRange[0] !== Infinity && $metricRange[0] !== null}
@@ -9,24 +24,34 @@
 		</span>
 		<span
 			contenteditable="true"
-			on:blur={(e) =>
-				metricRange.update((range) => {
-					range[0] = parseFloat(e.currentTarget.innerText);
-					return [...range];
-				})}
+			role="textbox"
+			aria-label="Metric range min"
+			tabindex="0"
+			on:keydown={(e) => {
+				if (e.key === 'Enter') {
+					e.preventDefault();
+					e.currentTarget.blur();
+				}
+			}}
+			on:blur={(e) => updateRange(e, 1)}
 		>
 			{$metricRange[0].toFixed(2)}
 		</span>
 		<div class="w-10 h-4 mx-2.5 bg-gradient-to-r from-primary-light to-primary" />
-		<span
+		<div
 			contenteditable="true"
-			on:blur={(e) =>
-				metricRange.update((range) => {
-					range[1] = parseFloat(e.currentTarget.innerText);
-					return [...range];
-				})}
+			role="textbox"
+			aria-label="Metric range max"
+			tabindex="0"
+			on:keydown={(e) => {
+				if (e.key === 'Enter') {
+					e.preventDefault();
+					e.currentTarget.blur();
+				}
+			}}
+			on:blur={(e) => updateRange(e, 1)}
 		>
 			{$metricRange[1].toFixed(2)}
-		</span>
+		</div>
 	</div>
 {/if}

--- a/frontend/src/lib/components/metadata/MetricRange.svelte
+++ b/frontend/src/lib/components/metadata/MetricRange.svelte
@@ -1,17 +1,22 @@
 <script lang="ts">
 	import { metric, metricRange, metrics } from '$lib/stores';
 
-	function updateRange(e: Event, i: number) {
+	/**
+	 * Updates the metric range.
+	 * @param e Blur event from contenteditable div
+	 * @param index 0 or 1 for whether this is the min or max element of the range
+	 */
+	function updateRange(e: Event, index: number) {
 		const target = e.target as HTMLElement;
 
 		let val = parseFloat(target.innerText);
 		if (isNaN(val)) {
-			target.innerText = $metricRange[i].toFixed(2);
+			target.innerText = $metricRange[index].toFixed(2);
 			return;
 		}
 
 		metricRange.update((range) => {
-			range[i] = val;
+			range[index] = val;
 			return [...range];
 		});
 	}
@@ -22,7 +27,7 @@
 		<span class="mx-4 whitespace-nowrap overflow-hidden text-ellipsis">
 			{$metric ? $metric.name : ''}
 		</span>
-		<span
+		<div
 			contenteditable="true"
 			role="textbox"
 			aria-label="Metric range min"
@@ -36,7 +41,7 @@
 			on:blur={(e) => updateRange(e, 1)}
 		>
 			{$metricRange[0].toFixed(2)}
-		</span>
+		</div>
 		<div class="w-10 h-4 mx-2.5 bg-gradient-to-r from-primary-light to-primary" />
 		<div
 			contenteditable="true"

--- a/frontend/src/lib/components/popups/Popup.svelte
+++ b/frontend/src/lib/components/popups/Popup.svelte
@@ -9,7 +9,7 @@
 </script>
 
 <button
-	class="absolute inset-0 z-20 flex justify-center items-baseline p-12 bg-grey bg-opacity-60"
+	class="text-left absolute inset-0 z-20 flex justify-center items-baseline p-12 bg-grey bg-opacity-60"
 	transition:fade={{ duration: 200 }}
 	bind:clientHeight={paperHeight}
 	on:mousedown={() => dispatch('close')}

--- a/frontend/src/lib/components/report/elements/SliceElement.svelte
+++ b/frontend/src/lib/components/report/elements/SliceElement.svelte
@@ -99,7 +99,7 @@
 			<div class="overflow-x-scroll flex flex-wrap content-start w-full h-full">
 				{#if sliceElementOptions.idColumn !== undefined && table.length > 0 && table[0][sliceElementOptions.idColumn] !== undefined}
 					{#each table as inst (inst[sliceElementOptions.idColumn])}
-						<div class="m-auto mt-0">
+						<div class="m-auto mt-0 w-1/2 px-1">
 							<InstanceView
 								view={sliceElementOptions.project.view}
 								dataColumn={sliceElementOptions.dataColumn}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,6 +10,9 @@ export default defineConfig({
 				secure: false,
 				rewrite: (path) => path.replace(/^\/dockerzeno/, '')
 			}
+		},
+		fs: {
+			allow: ['.yalc']
 		}
 	},
 	plugins: [sveltekit()],


### PR DESCRIPTION
# Description
* Add two options to use yalc for locally using instances package: https://stackoverflow.com/questions/68670700/npm-link-dev-packages-when-using-docker-dev-containers
* Fix ZEN-295
* Fix ZEN-291 - Use grid view in instances and fixed half-width in reports for instance view to fill space. Eventually want to make it more customizable, for now it's max width of 400.
* Fix ZEN-294 - validate range and set on enter.
* Fix ZEN-289