### PR TITLE
refactor: implement custom tooltip to fix errors with tooltip library

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -36,7 +36,6 @@
 				"@smui/icon-button": "^7.0.0-beta.8",
 				"@smui/paper": "7.0.0-beta.15",
 				"@smui/textfield": "^7.0.0-beta.15",
-				"@svelte-plugins/tooltips": "^0.1.6",
 				"@sveltejs/adapter-node": "^1.3.1",
 				"@sveltejs/kit": "^1.27.0",
 				"@tailwindcss/typography": "^0.5.10",
@@ -1748,12 +1747,6 @@
 				"@smui/ripple": "^7.0.0-beta.15",
 				"svelte2tsx": "^0.6.21"
 			}
-		},
-		"node_modules/@svelte-plugins/tooltips": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/@svelte-plugins/tooltips/-/tooltips-0.1.8.tgz",
-			"integrity": "sha512-k0qQ3h7/rQN7aIk/Jvgp89kgH+P0QGDQZWGraj69tEWUY+UoK8a21UH7JDo8X4hjVD2pWIVYj6XGHjijPhRyzg==",
-			"dev": true
 		},
 		"node_modules/@sveltejs/adapter-node": {
 			"version": "1.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,6 @@
 		"@smui/icon-button": "^7.0.0-beta.8",
 		"@smui/paper": "7.0.0-beta.15",
 		"@smui/textfield": "^7.0.0-beta.15",
-		"@svelte-plugins/tooltips": "^0.1.6",
 		"@sveltejs/adapter-node": "^1.3.1",
 		"@sveltejs/kit": "^1.27.0",
 		"@tailwindcss/typography": "^0.5.10",

--- a/frontend/src/lib/components/general/HeaderIcon.svelte
+++ b/frontend/src/lib/components/general/HeaderIcon.svelte
@@ -1,29 +1,28 @@
 <script lang="ts">
 	import { page } from '$app/stores';
+	import { tooltip } from '$lib/util/tooltip';
 	import { Icon } from '@smui/icon-button';
-	import { Tooltip } from '@svelte-plugins/tooltips';
 
 	export let pageName: string;
 	export let tooltipContent: string;
 	export let icon: string;
 </script>
 
-<Tooltip content={tooltipContent} theme={'zeno-tooltip'} position="right">
-	<button
-		class="m-auto flex items-center cursor-pointer p-3 hover:bg-black-transparent {$page.url.href.includes(
-			pageName
-		)
-			? 'font-medium'
-			: ''}"
-		on:click
-	>
-		<div class="w-6 h-6 fill-grey">
-			<Icon style="outline:none" tag="svg" viewBox="0 0 24 24">
-				<path
-					class={`${$page.url.href.includes(pageName) ? 'fill-primary' : 'fill-grey'}`}
-					d={icon}
-				/>
-			</Icon>
-		</div>
-	</button>
-</Tooltip>
+<button
+	class="m-auto flex items-center cursor-pointer p-3 hover:bg-black-transparent {$page.url.href.includes(
+		pageName
+	)
+		? 'font-medium'
+		: ''}"
+	on:click
+	use:tooltip={{ text: tooltipContent }}
+>
+	<div class="w-6 h-6 fill-grey">
+		<Icon style="outline:none" tag="svg" viewBox="0 0 24 24">
+			<path
+				class={`${$page.url.href.includes(pageName) ? 'fill-primary' : 'fill-grey'}`}
+				d={icon}
+			/>
+		</Icon>
+	</div>
+</button>

--- a/frontend/src/lib/components/general/HomeHeader.svelte
+++ b/frontend/src/lib/components/general/HomeHeader.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import { showNewReport } from '$lib/stores';
+	import { tooltip } from '$lib/util/tooltip';
 	import { mdiPlus } from '@mdi/js';
 	import { Icon } from '@smui/button';
 	import Button from '@smui/button/src/Button.svelte';
-	import { Tooltip } from '@svelte-plugins/tooltips';
 
 	export let user = '';
 
@@ -12,32 +12,22 @@
 </script>
 
 <div class="flex mb-4 items-center h-10">
-	<Tooltip
-		content={'Projects are datasets and system outputs for evaluation'}
-		theme={'zeno-tooltip'}
-		position="bottom"
-	>
-		<a
-			href={user ? '/' + user + '/projects' : '/projects'}
-			class="text-xl mr-6 text-black hover:text-primary p-2 rounded
+	<a
+		href={user ? '/' + user + '/projects' : '/projects'}
+		class="text-xl mr-6 text-black hover:text-primary p-2 rounded
         {view === 'projects' ? 'bg-grey-lighter' : 'text-grey-dark'}"
-		>
-			Projects
-		</a>
-	</Tooltip>
-	<Tooltip
-		content={'Reports are interactive notebooks for sharing evaluation insights'}
-		theme={'zeno-tooltip'}
-		position="bottom"
+		use:tooltip={{ text: 'Projects are collections of datasets, models, and evaluations' }}
 	>
-		<a
-			href={user ? '/' + user + '/reports' : '/reports'}
-			class="text-xl mr-6 text-black hover:text-primary p-2 rounded
+		Projects
+	</a>
+	<a
+		href={user ? '/' + user + '/reports' : '/reports'}
+		class="text-xl mr-6 text-black hover:text-primary p-2 rounded
         {view === 'reports' ? 'bg-grey-lighter' : 'text-grey-dark'}"
-		>
-			Reports
-		</a>
-	</Tooltip>
+		use:tooltip={{ text: 'Reports are interactive notebooks for sharing evaluation insights' }}
+	>
+		Reports
+	</a>
 	{#if view === 'reports' && user}
 		<Button on:click={() => showNewReport.set(true)}>
 			<Icon class="material-icons" width="24px" height="24px" tag="svg" viewBox="0 0 24 24">

--- a/frontend/src/lib/components/general/LikeButton.svelte
+++ b/frontend/src/lib/components/general/LikeButton.svelte
@@ -1,51 +1,47 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import { page } from '$app/stores';
+	import { tooltip } from '$lib/util/tooltip';
 	import type { User } from '$lib/zenoapi';
 	import { mdiHeart, mdiHeartOutline } from '@mdi/js';
 	import { Icon } from '@smui/button';
-	import { Tooltip } from '@svelte-plugins/tooltips';
 	import { createEventDispatcher } from 'svelte';
 
 	export let likes: number;
 	export let liked: boolean;
 	export let user: User | null;
 	export let report = false;
-	export let tooltipPos = 'bottom';
 
 	const dispatch = createEventDispatcher();
 </script>
 
 <div class="flex ml-auto">
 	<div class="flex">
-		<p class="mr-2 text-base font-semibold text-primary">{likes}</p>
-		<Tooltip
-			content={`${user === null ? 'Login to l' : 'L'}ike this ${report ? 'report' : 'project'}!`}
-			theme={'zeno-tooltip'}
-			position={tooltipPos}
-		>
-			<button
-				class=" w-6 h-6 fill-primary"
-				on:click={(e) => {
-					if (user) {
-						e.stopPropagation();
-						if (liked) {
-							liked = false;
-							likes = Math.max(0, likes - 1);
-						} else {
-							liked = true;
-							likes++;
-						}
-						dispatch('like');
+		<p class="pr-2 text-base font-semibold text-primary">{likes}</p>
+		<button
+			use:tooltip={{
+				text: `${user === null ? 'Login to l' : 'L'}ike this ${report ? 'report' : 'project'}!`
+			}}
+			class=" w-6 h-6 fill-primary"
+			on:click={(e) => {
+				if (user) {
+					e.stopPropagation();
+					if (liked) {
+						liked = false;
+						likes = Math.max(0, likes - 1);
 					} else {
-						goto(`/login?redirectTo=${$page.url.pathname}`);
+						liked = true;
+						likes++;
 					}
-				}}
-			>
-				<Icon tag="svg" viewBox="0 0 24 24">
-					<path d={user === null || liked ? mdiHeart : mdiHeartOutline} />
-				</Icon>
-			</button>
-		</Tooltip>
+					dispatch('like');
+				} else {
+					goto(`/login?redirectTo=${$page.url.pathname}`);
+				}
+			}}
+		>
+			<Icon tag="svg" viewBox="0 0 24 24">
+				<path d={user === null || liked ? mdiHeart : mdiHeartOutline} />
+			</Icon>
+		</button>
 	</div>
 </div>

--- a/frontend/src/lib/components/general/Tooltip.svelte
+++ b/frontend/src/lib/components/general/Tooltip.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import { tooltipState } from '$lib/stores';
+	import { fade } from 'svelte/transition';
+
+	let windowWidth = 0;
+	let windowHeight = 0;
+	let tooltipWidth = 0;
+	let tooltipHeight = 0;
+
+	$: yPos =
+		windowHeight > $tooltipState.mousePos.y + tooltipHeight + 20
+			? $tooltipState.mousePos.y
+			: $tooltipState.mousePos.y - tooltipHeight - 20;
+	$: xStyle =
+		windowWidth > $tooltipState.mousePos.x + tooltipWidth + 10
+			? `left: ${$tooltipState.mousePos.x}px;`
+			: `right: 10px;`;
+	$: style = `top: ${yPos}px; ${xStyle};`;
+</script>
+
+<svelte:window bind:innerWidth={windowWidth} bind:innerHeight={windowHeight} />
+{#if $tooltipState.hover && $tooltipState.text !== undefined}
+	<div
+		class="bg-yellowish-light text-grey text-sm fixed p-1 rounded shadow z-30 flex my-4"
+		{style}
+		transition:fade
+		bind:offsetWidth={tooltipWidth}
+		bind:offsetHeight={tooltipHeight}
+	>
+		<div class="flex flex-col p-2 break-all">
+			{$tooltipState.text}
+		</div>
+	</div>
+{/if}

--- a/frontend/src/lib/components/metadata/HistogramsHeader.svelte
+++ b/frontend/src/lib/components/metadata/HistogramsHeader.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import MetricRange from '$lib/components/metadata/MetricRange.svelte';
 	import { requestingHistogramCounts } from '$lib/stores';
+	import { tooltip } from '$lib/util/tooltip';
 	import { mdiInformationOutline } from '@mdi/js';
 	import CircularProgress from '@smui/circular-progress';
 	import { Icon } from '@smui/icon-button';
-	import { tooltip } from '@svelte-plugins/tooltips';
 </script>
 
 <div
@@ -15,10 +15,7 @@
 		<div
 			class="w-6 h-6 cursor-help fill-grey-dark"
 			use:tooltip={{
-				content:
-					'Interactive distributions for metadata columns. Click or drag on the histograms to filter the data',
-				position: 'right',
-				theme: 'zeno-tooltip'
+				text: 'Interactive distributions for metadata columns. Click or drag on the histograms to filter the data'
 			}}
 		>
 			<Icon style="outline:none" tag="svg" viewBox="-6 -6 36 36">

--- a/frontend/src/lib/components/metadata/SliceHeader.svelte
+++ b/frontend/src/lib/components/metadata/SliceHeader.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import { models, project, selectionIds, selectionPredicates, selections } from '$lib/stores';
+	import { tooltip } from '$lib/util/tooltip';
 	import {
 		mdiCreation,
 		mdiCreationOutline,
@@ -10,7 +11,6 @@
 		mdiPlusCircle
 	} from '@mdi/js';
 	import IconButton, { Icon } from '@smui/icon-button';
-	import { tooltip } from '@svelte-plugins/tooltips';
 	import FolderPopup from '../popups/FolderPopup.svelte';
 	import SliceFinderPopup from '../popups/SliceFinderPopup.svelte';
 	import SlicePopup from '../popups/SlicePopup.svelte';
@@ -39,9 +39,7 @@
 		<div
 			class="w-6 h-6 cursor-help fill-grey-dark"
 			use:tooltip={{
-				content: 'Slices are named combinations of filters',
-				position: 'right',
-				theme: 'zeno-tooltip'
+				text: 'Slices are named combinations of filters'
 			}}
 		>
 			<Icon style="outline:none" tag="svg" viewBox="-6 -6 36 36">
@@ -53,12 +51,9 @@
 		<div class="flex items-center justify-between">
 			<div
 				use:tooltip={{
-					content: !$page.url.href.includes('compare')
+					text: !$page.url.href.includes('compare')
 						? 'Find underperforming slices'
-						: 'Find slices with the largest output differences between systems',
-					position: 'left',
-					theme: 'zeno-tooltip',
-					maxWidth: '150'
+						: 'Find slices with the largest output differences between systems'
 				}}
 			>
 				<IconButton
@@ -77,9 +72,7 @@
 			</div>
 			<div
 				use:tooltip={{
-					content: 'Create a new folder',
-					position: 'left',
-					theme: 'zeno-tooltip'
+					text: 'Create a new folder'
 				}}
 			>
 				<IconButton
@@ -94,9 +87,7 @@
 			</div>
 			<div
 				use:tooltip={{
-					content: 'Create a new slice',
-					position: 'left',
-					theme: 'zeno-tooltip'
+					text: 'Create a new slice'
 				}}
 			>
 				<IconButton

--- a/frontend/src/lib/components/metadata/Tags.svelte
+++ b/frontend/src/lib/components/metadata/Tags.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import { editTag, editedIds, project, selectionIds, selections, tagIds, tags } from '$lib/stores';
+	import { tooltip } from '$lib/util/tooltip';
 	import type { Tag, ZenoService } from '$lib/zenoapi';
 	import { mdiInformationOutline, mdiPlus, mdiPlusCircle } from '@mdi/js';
 	import Button from '@smui/button';
 	import IconButton, { Icon } from '@smui/icon-button';
-	import { tooltip } from '@svelte-plugins/tooltips';
 	import { getContext } from 'svelte';
 	import TagPopup from '../popups/TagPopup.svelte';
 	import TagCell from './cells/TagCell.svelte';
@@ -50,9 +50,7 @@
 		<div
 			class="w-6 h-6 cursor-help fill-grey-darker"
 			use:tooltip={{
-				content: 'Tags are named sets of data instances',
-				position: 'right',
-				theme: 'zeno-tooltip'
+				text: 'Tags are named sets of data instances'
 			}}
 		>
 			<Icon tag="svg" viewBox="-6 -6 36 36">
@@ -64,9 +62,7 @@
 		<div class="flex items-center justify-between">
 			<div
 				use:tooltip={{
-					content: 'Create a new tag',
-					position: 'left',
-					theme: 'zeno-tooltip'
+					text: 'Create a new tag'
 				}}
 			>
 				<IconButton on:click={() => (showNewTag = true)}>

--- a/frontend/src/lib/components/metadata/cells/metadata-cells/SearchOption.svelte
+++ b/frontend/src/lib/components/metadata/cells/metadata-cells/SearchOption.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { tooltip } from '@svelte-plugins/tooltips';
+	import { tooltip } from '$lib/util/tooltip';
 
 	export let highlighted: boolean;
 	export let id: string;
@@ -13,9 +13,7 @@
 	}`}
 	on:click
 	use:tooltip={{
-		content: tooltipContent,
-		theme: 'zeno-tooltip',
-		autoPosition: true
+		text: tooltipContent
 	}}
 >
 	<slot />

--- a/frontend/src/lib/components/popups/SliceFinderPopup.svelte
+++ b/frontend/src/lib/components/popups/SliceFinderPopup.svelte
@@ -10,6 +10,7 @@
 		selections,
 		tagIds
 	} from '$lib/stores';
+	import { tooltip } from '$lib/util/tooltip';
 	import { columnSort } from '$lib/util/util';
 	import {
 		MetadataType,
@@ -21,7 +22,6 @@
 	import { mdiClose, mdiInformationOutline } from '@mdi/js';
 	import Button from '@smui/button';
 	import IconButton, { Icon } from '@smui/icon-button';
-	import { tooltip } from '@svelte-plugins/tooltips';
 	import Svelecte from 'svelecte';
 	import { createEventDispatcher, getContext } from 'svelte';
 	import ChipsWrapper from '../metadata/ChipsWrapper.svelte';
@@ -141,12 +141,9 @@
 			<div
 				class="w-6 h-6 cursor-help fill-grey-dark"
 				use:tooltip={{
-					content: $page.url.href.includes('compare')
+					text: $page.url.href.includes('compare')
 						? 'Run the SliceLine algorithm to find slices with the largest or smallest average difference in a difference column between two systems'
-						: 'Run the SliceLine algorithm to find slices of data with high or low metrics',
-					position: 'right',
-					theme: 'zeno-tooltip',
-					maxWidth: '350'
+						: 'Run the SliceLine algorithm to find slices of data with high or low metrics'
 				}}
 			>
 				<Icon style="outline:none" tag="svg" viewBox="-6 -6 36 36">
@@ -170,12 +167,9 @@
 					class="w-6 h-6 cursor-help fill-grey-dark"
 					style="margin-top: 3px;"
 					use:tooltip={{
-						content: $page.url.href.includes('compare')
+						text: $page.url.href.includes('compare')
 							? 'The column on which to measure system disagreement'
-							: 'The continuous column to compare slices across',
-						position: 'right',
-						theme: 'zeno-tooltip',
-						maxWidth: '450'
+							: 'The continuous column to compare slices across'
 					}}
 				>
 					<Icon style="outline:none" tag="svg" viewBox="-6 -6 36 36">
@@ -200,10 +194,7 @@
 					class="w-6 h-6 cursor-help fill-grey-dark"
 					style="margin-top: 3px;"
 					use:tooltip={{
-						content: 'Metadata columns used to create slices',
-						position: 'top',
-						theme: 'zeno-tooltip',
-						maxWidth: '450'
+						text: 'Metadata columns used to create slices'
 					}}
 				>
 					<Icon style="outline:none" tag="svg" viewBox="-6 -6 36 36">
@@ -229,11 +220,7 @@
 					class="w-6 h-6 cursor-help fill-grey-dark"
 					style="margin-top: 3px;"
 					use:tooltip={{
-						content:
-							'Weight parameter for the average slice metric. Increase it to find more slices',
-						theme: 'zeno-tooltip',
-						maxWidth: '195',
-						position: 'left'
+						text: 'Weight parameter for the average slice metric. Increase it to find more slices'
 					}}
 				>
 					<Icon style="outline:none" tag="svg" viewBox="-6 -6 36 36">
@@ -256,9 +243,7 @@
 					class="w-6 h-6 cursor-help fill-grey-dark"
 					style="margin-top: 3px;"
 					use:tooltip={{
-						content: 'Maximum number of predicates',
-						theme: 'zeno-tooltip',
-						maxWidth: '270'
+						text: 'Maximum number of predicates'
 					}}
 				>
 					<Icon style="outline:none" tag="svg" viewBox="-6 -6 36 36">
@@ -280,12 +265,9 @@
 					class="w-6 h-6 cursor-help fill-grey-dark"
 					style="margin-top: 3px;"
 					use:tooltip={{
-						content: $page.url.href.includes('compare')
+						text: $page.url.href.includes('compare')
 							? 'Order by slice score, a combination of system difference and size'
-							: 'Order by slice score, a combination of size and metric',
-						theme: 'zeno-tooltip',
-						position: 'left',
-						maxWidth: '250'
+							: 'Order by slice score, a combination of size and metric'
 					}}
 				>
 					<Icon style="outline:none" tag="svg" viewBox="-6 -6 36 36">

--- a/frontend/src/lib/components/project/Project.svelte
+++ b/frontend/src/lib/components/project/Project.svelte
@@ -7,7 +7,6 @@
 	import { Icon } from '@smui/button';
 	import IconButton from '@smui/icon-button';
 	import Paper, { Content } from '@smui/paper';
-	import { Tooltip } from '@svelte-plugins/tooltips';
 	import { getContext } from 'svelte';
 	import LikeButton from '../general/LikeButton.svelte';
 	import Confirm from '../popups/Confirm.svelte';
@@ -120,24 +119,20 @@
 		{project.description}
 	</p>
 	<div class="flex items-center w-full mb-2 mt-3">
-		<Tooltip
-			content={`This project has ${shortenNumber(stats.numInstances, 1)} data point${
+		<ProjectStat
+			icon={getProjectIcon()}
+			text={stats.numInstances}
+			tooltipContent={`This project has ${shortenNumber(stats.numInstances, 1)} data point${
 				stats.numInstances !== 1 ? 's' : ''
 			}.`}
-			theme={'zeno-tooltip'}
-			position="bottom"
-		>
-			<ProjectStat icon={getProjectIcon()} text={stats.numInstances} />
-		</Tooltip>
-		<Tooltip
-			content={`This project has ${shortenNumber(stats.numModels, 1)} system${
+		/>
+		<ProjectStat
+			icon={mdiLayersTriple}
+			text={stats.numModels}
+			tooltipContent={`This project has ${shortenNumber(stats.numModels, 1)} system${
 				stats.numModels !== 1 ? 's' : ''
 			}.`}
-			theme={'zeno-tooltip'}
-			position="bottom"
-		>
-			<ProjectStat icon={mdiLayersTriple} text={stats.numModels} />
-		</Tooltip>
+		/>
 		<LikeButton
 			on:like={() => zenoClient.likeProject(project.uuid)}
 			{user}

--- a/frontend/src/lib/components/project/ProjectHeader.svelte
+++ b/frontend/src/lib/components/project/ProjectHeader.svelte
@@ -16,11 +16,5 @@
 	<p class="px-4 pt-1 text-grey-dark text-ellipsis overflow-hidden whitespace-nowrap">
 		{project.description}
 	</p>
-	<LikeButton
-		on:like={() => zenoClient.likeProject(project.uuid)}
-		{likes}
-		{liked}
-		{user}
-		tooltipPos="left"
-	/>
+	<LikeButton on:like={() => zenoClient.likeProject(project.uuid)} {likes} {liked} {user} />
 </div>

--- a/frontend/src/lib/components/project/ProjectStat.svelte
+++ b/frontend/src/lib/components/project/ProjectStat.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
+	import { tooltip } from '$lib/util/tooltip';
 	import { shortenNumber } from '$lib/util/util';
 	import { Icon } from '@smui/button';
 
 	export let icon: string;
 	export let text: string | number;
+	export let tooltipContent: string;
 </script>
 
-<div class="flex items-center mr-8">
+<div class="flex items-center mr-8" use:tooltip={{ text: tooltipContent }}>
 	<div class="w-6 h-6 fill-grey-dark mr-2">
 		<Icon style="outline:none" tag="svg" viewBox="0 0 24 24">
 			<path d={icon} />

--- a/frontend/src/lib/components/report/Report.svelte
+++ b/frontend/src/lib/components/report/Report.svelte
@@ -8,7 +8,6 @@
 	import { Icon } from '@smui/button';
 	import IconButton from '@smui/icon-button';
 	import Paper, { Content } from '@smui/paper';
-	import { Tooltip } from '@svelte-plugins/tooltips';
 	import { getContext } from 'svelte';
 	import LikeButton from '../general/LikeButton.svelte';
 	import Confirm from '../popups/Confirm.svelte';
@@ -95,24 +94,20 @@
 		{report.description}
 	</p>
 	<div class="flex items-center w-full mb-2 mt-3">
-		<Tooltip
-			content={`This report has ${shortenNumber(stats.numProjects, 1)} project${
+		<ProjectStat
+			icon={mdiFileTree}
+			text={stats.numProjects}
+			tooltipContent={`This report has ${shortenNumber(stats.numProjects, 1)} project${
 				stats.numProjects !== 1 ? 's' : ''
 			} linked to it.`}
-			theme={'zeno-tooltip'}
-			position="bottom"
-		>
-			<ProjectStat icon={mdiFileTree} text={stats.numProjects} />
-		</Tooltip>
-		<Tooltip
-			content={`This report has ${shortenNumber(stats.numElements, 1)} element${
+		/>
+		<ProjectStat
+			icon={mdiSitemap}
+			text={stats.numElements}
+			tooltipContent={`This report has ${shortenNumber(stats.numElements, 1)} element${
 				stats.numElements !== 1 ? 's' : ''
 			}.`}
-			theme={'zeno-tooltip'}
-			position="bottom"
-		>
-			<ProjectStat icon={mdiSitemap} text={stats.numElements} />
-		</Tooltip>
+		/>
 		<LikeButton
 			on:like={() => zenoClient.likeReport(report.id)}
 			likes={stats.numLikes}

--- a/frontend/src/lib/components/settings/OrganizationsTable.svelte
+++ b/frontend/src/lib/components/settings/OrganizationsTable.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
+	import { tooltip } from '$lib/util/tooltip';
 	import type { Organization, User, ZenoService } from '$lib/zenoapi';
 	import { mdiClose, mdiCog, mdiLogout, mdiPlus } from '@mdi/js';
 	import { Icon } from '@smui/button';
 	import IconButton from '@smui/icon-button/src/IconButton.svelte';
-	import { tooltip } from '@svelte-plugins/tooltips';
 	import { getContext } from 'svelte';
 	import Confirm from '../popups/Confirm.svelte';
 	import OrganizationPopup from '../popups/OrganizationPopup.svelte';
@@ -94,9 +94,7 @@
 							<div class="flex items-center justify-end">
 								<div
 									use:tooltip={{
-										content: 'Manage this organization. You can only do this if you are an admin',
-										position: 'left',
-										theme: 'zeno-tooltip'
+										text: 'Manage this organization. You can only do this if you are an admin'
 									}}
 								>
 									<IconButton
@@ -112,10 +110,7 @@
 								</div>
 								<div
 									use:tooltip={{
-										content:
-											'Leave this organization. You can only do this if there is an admin left',
-										position: 'left',
-										theme: 'zeno-tooltip'
+										text: 'Leave this organization. You can only do this if there is an admin left'
 									}}
 								>
 									<IconButton
@@ -151,9 +146,7 @@
 								</div>
 								<div
 									use:tooltip={{
-										content: 'Delete this organization. You can only do this if you are an admin',
-										position: 'left',
-										theme: 'zeno-tooltip'
+										text: 'Delete this organization. You can only do this if you are an admin'
 									}}
 								>
 									<IconButton

--- a/frontend/src/lib/stores.ts
+++ b/frontend/src/lib/stores.ts
@@ -111,3 +111,15 @@ export const featureFlags: Writable<Record<string, boolean>> = writable({});
 
 // Whether the new report popup should be displayed on the reports page
 export const showNewReport = writable(false);
+
+export interface TooltipSpec {
+	hover: boolean;
+	mousePos: { x: number; y: number };
+	text: undefined | string;
+}
+
+export const tooltipState = writable<TooltipSpec>({
+	hover: false,
+	mousePos: { x: 0, y: 0 },
+	text: undefined
+});

--- a/frontend/src/lib/util/tooltip.ts
+++ b/frontend/src/lib/util/tooltip.ts
@@ -1,0 +1,31 @@
+import { tooltipState } from '$lib/stores';
+
+export function tooltip(node: HTMLElement, params: { text: string }) {
+	function handleFocus(e: MouseEvent) {
+		tooltipState.set({ hover: true, mousePos: { x: e.clientX, y: e.clientY }, text: params.text });
+
+		node.addEventListener('mouseleave', handleBlur);
+		node.addEventListener('mousemove', handleMove);
+		node.removeEventListener('mouseenter', handleFocus);
+	}
+
+	function handleMove(e: MouseEvent) {
+		tooltipState.set({ hover: true, mousePos: { x: e.clientX, y: e.clientY }, text: params.text });
+	}
+
+	function handleBlur() {
+		tooltipState.set({ hover: false, mousePos: { x: 0, y: 0 }, text: undefined });
+
+		node.removeEventListener('mouseleave', handleBlur);
+		node.removeEventListener('mousemove', handleMove);
+		node.addEventListener('mouseenter', handleFocus);
+	}
+
+	node.addEventListener('mouseenter', handleFocus);
+
+	return {
+		destroy() {
+			node.removeEventListener('mouseenter', handleFocus);
+		}
+	};
+}

--- a/frontend/src/routes/(app)/(home)/+layout.svelte
+++ b/frontend/src/routes/(app)/(home)/+layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import HomeHeader from '$lib/components/general/HomeHeader.svelte';
-	import { Tooltip } from '@svelte-plugins/tooltips';
+	import { tooltip } from '$lib/util/tooltip';
 
 	export let data;
 
@@ -12,22 +12,20 @@
 <div class="flex flex-col w-full h-full p-8 pt-5 bg-white">
 	{#if data.cognitoUser && data.cognitoUser !== null}
 		<div class="flex text-3xl">
-			<Tooltip content={'Your projects and reports'} theme={'zeno-tooltip'} position="bottom">
-				<a
-					href={'/' + data.cognitoUser.name + '/projects'}
-					class={`mr-6 ${isExplore ? 'text-grey-dark' : ''} hover:text-primary uppercase font-bold`}
-				>
-					My Hub
-				</a>
-			</Tooltip>
-			<Tooltip content={'Public projects and reports'} theme={'zeno-tooltip'} position="bottom">
-				<a
-					href="/projects"
-					class={`${!isExplore ? 'text-grey-dark' : ''} hover:text-primary uppercase font-bold`}
-				>
-					Discover
-				</a>
-			</Tooltip>
+			<a
+				href={'/' + data.cognitoUser.name + '/projects'}
+				class={`mr-6 ${isExplore ? 'text-grey-dark' : ''} hover:text-primary uppercase font-bold`}
+				use:tooltip={{ text: 'Your projects and reports' }}
+			>
+				My Hub
+			</a>
+			<a
+				href="/projects"
+				class={`${!isExplore ? 'text-grey-dark' : ''} hover:text-primary uppercase font-bold`}
+				use:tooltip={{ text: 'Public projects and reports' }}
+			>
+				Discover
+			</a>
 		</div>
 	{:else}
 		<div

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -3,7 +3,7 @@
 	import { onNavigate } from '$app/navigation';
 	import { env } from '$env/dynamic/public';
 	import Tooltip from '$lib/components/general/Tooltip.svelte';
-	import { featureFlags } from '$lib/stores';
+	import { featureFlags, tooltipState } from '$lib/stores';
 	import { zenoFeatureFlags } from '$lib/util/features';
 	import * as amplitude from '@amplitude/analytics-browser';
 	import '../app.css';
@@ -18,6 +18,12 @@
 		});
 
 	onNavigate((navigation) => {
+		tooltipState.set({
+			hover: false,
+			mousePos: { x: 0, y: 0 },
+			text: undefined
+		});
+
 		if (!document.startViewTransition) return;
 
 		return new Promise((resolve) => {

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
 	import { browser } from '$app/environment';
 	import { onNavigate } from '$app/navigation';
 	import { env } from '$env/dynamic/public';
+	import Tooltip from '$lib/components/general/Tooltip.svelte';
 	import { featureFlags } from '$lib/stores';
 	import { zenoFeatureFlags } from '$lib/util/features';
 	import * as amplitude from '@amplitude/analytics-browser';
@@ -30,4 +31,5 @@
 
 <div class="w-full h-full overflow-hidden">
 	<slot />
+	<Tooltip />
 </div>

--- a/frontend/src/theme/_smui-theme.scss
+++ b/frontend/src/theme/_smui-theme.scss
@@ -140,13 +140,6 @@ body {
 	cursor: pointer;
 }
 
-.tooltip.zeno-tooltip {
-	--tooltip-background-color: var(--Y2);
-	--tooltip-color: var(--G1);
-	--tooltip-font-family: 'Open Sans', 'Roboto', sans-serif;
-	--tooltip-box-shadow: 2px 2px 2px 2px rgb(0 0 0 / 0.1);
-}
-
 /* Fix: smui + tailwind adds left & right borders within textfields */
 .mdc-text-field--outlined .mdc-notched-outline--notched .mdc-notched-outline__notch {
 	border-left: 0;

--- a/frontend/static/smui.css
+++ b/frontend/static/smui.css
@@ -103,12 +103,6 @@ body {
 .remove {
 	cursor: pointer;
 }
-.tooltip.zeno-tooltip {
-	--tooltip-background-color: var(--Y2);
-	--tooltip-color: var(--G1);
-	--tooltip-font-family: 'Open Sans', 'Roboto', sans-serif;
-	--tooltip-box-shadow: 2px 2px 2px 2px rgb(0 0 0 / 0.1);
-}
 .mdc-text-field--outlined .mdc-notched-outline--notched .mdc-notched-outline__notch {
 	border-left: 0;
 	border-right: 0;


### PR DESCRIPTION
# Description

fix ZEN-305

Implements a custom tooltip that uses the `use:` directive to listen to mouse events and uses a global tooltip state and element.