### PR TITLE
fix: truncate project or report title to prevent overflow

### DIFF
--- a/frontend/src/lib/components/home/HomeCard.svelte
+++ b/frontend/src/lib/components/home/HomeCard.svelte
@@ -78,7 +78,7 @@
 	class="flex flex-col rounded-lg border border-solid border-grey-light px-4 py-2 shadow-sm hover:shadow-md"
 >
 	<div class="flex w-full items-center justify-between">
-		<p class="text-left text-lg text-black">{entry.name}</p>
+		<p class="truncate text-left text-lg text-black">{entry.name}</p>
 		<div class="flex items-center">
 			<div
 				class="relative mr-2 h-9 w-9"


### PR DESCRIPTION
# Description

<img width="725" alt="image" src="https://github.com/zeno-ml/zeno-hub/assets/5690524/113263ad-e4cd-4cfd-8cec-2d51ea592967">
