### PR TITLE
build: add back prettier-plugin-svelte to fix format

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -51,6 +51,7 @@
 				"eslint-plugin-svelte": "^2.33.0",
 				"postcss": "^8.4.29",
 				"prettier": "^3.0.3",
+				"prettier-plugin-svelte": "^3.0.3",
 				"prettier-plugin-tailwindcss": "^0.5.6",
 				"shx": "^0.3.4",
 				"simple-svelte-autocomplete": "^2.5.2",
@@ -1782,9 +1783,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "1.27.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.27.1.tgz",
-			"integrity": "sha512-nYkOUJKbeI8fcwvt/cyhTdz6VG4kT6XVprNnzfIwif+IZ8RvxvJuPhPhYjz14ASIcMLpq8xC6D3X4xH3bvWi+Q==",
+			"version": "1.27.2",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.27.2.tgz",
+			"integrity": "sha512-2w2VbPpK8DI3QCSVa2UNAv5sKNks1LT8GsEdpk41ffOyO2znGx2ZwcRWacsqlvh3d9lncZuDdANvCbTbuKvy3Q==",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte": "^2.4.1",
@@ -1937,9 +1938,9 @@
 			}
 		},
 		"node_modules/@types/estree": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.3.tgz",
-			"integrity": "sha512-CS2rOaoQ/eAgAfcTfq6amKG7bsN+EMcgGY4FAFQdvSj2y1ixvOZTUA9mOtCai7E1SYu283XNw7urKK30nP3wkQ=="
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.4.tgz",
+			"integrity": "sha512-2JwWnHK9H+wUZNorf2Zr6ves96WHoWDJIftkcxPKsS7Djta6Zu519LarhRNljPXkpsZR2ZMwNCPeW7omW07BJw=="
 		},
 		"node_modules/@types/geojson": {
 			"version": "7946.0.4",
@@ -1953,9 +1954,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "20.8.9",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.9.tgz",
-			"integrity": "sha512-UzykFsT3FhHb1h7yD4CA4YhBHq545JC0YnEz41xkipN88eKQtL6rSgocL5tbAP6Ola9Izm/Aw4Ora8He4x0BHg==",
+			"version": "20.8.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
+			"integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
 			"devOptional": true,
 			"dependencies": {
 				"undici-types": "~5.26.4"
@@ -1985,16 +1986,16 @@
 			"integrity": "sha512-I3pkr8j/6tmQtKV/ZzHtuaqYSQvyjGRKH4go60Rr0IDLlFxuRT5V32uvB1mecM5G1EVAUyF/4r4QZ1GHgz+mxA=="
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.9.0.tgz",
-			"integrity": "sha512-lgX7F0azQwRPB7t7WAyeHWVfW1YJ9NIgd9mvGhfQpRY56X6AVf8mwM8Wol+0z4liE7XX3QOt8MN1rUKCfSjRIA==",
+			"version": "6.9.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.9.1.tgz",
+			"integrity": "sha512-w0tiiRc9I4S5XSXXrMHOWgHgxbrBn1Ro+PmiYhSg2ZVdxrAJtQgzU5o2m1BfP6UOn7Vxcc6152vFjQfmZR4xEg==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.5.1",
-				"@typescript-eslint/scope-manager": "6.9.0",
-				"@typescript-eslint/type-utils": "6.9.0",
-				"@typescript-eslint/utils": "6.9.0",
-				"@typescript-eslint/visitor-keys": "6.9.0",
+				"@typescript-eslint/scope-manager": "6.9.1",
+				"@typescript-eslint/type-utils": "6.9.1",
+				"@typescript-eslint/utils": "6.9.1",
+				"@typescript-eslint/visitor-keys": "6.9.1",
 				"debug": "^4.3.4",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.2.4",
@@ -2020,15 +2021,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.9.0.tgz",
-			"integrity": "sha512-GZmjMh4AJ/5gaH4XF2eXA8tMnHWP+Pm1mjQR2QN4Iz+j/zO04b9TOvJYOX2sCNIQHtRStKTxRY1FX7LhpJT4Gw==",
+			"version": "6.9.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.9.1.tgz",
+			"integrity": "sha512-C7AK2wn43GSaCUZ9do6Ksgi2g3mwFkMO3Cis96kzmgudoVaKyt62yNzJOktP0HDLb/iO2O0n2lBOzJgr6Q/cyg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "6.9.0",
-				"@typescript-eslint/types": "6.9.0",
-				"@typescript-eslint/typescript-estree": "6.9.0",
-				"@typescript-eslint/visitor-keys": "6.9.0",
+				"@typescript-eslint/scope-manager": "6.9.1",
+				"@typescript-eslint/types": "6.9.1",
+				"@typescript-eslint/typescript-estree": "6.9.1",
+				"@typescript-eslint/visitor-keys": "6.9.1",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -2048,13 +2049,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.9.0.tgz",
-			"integrity": "sha512-1R8A9Mc39n4pCCz9o79qRO31HGNDvC7UhPhv26TovDsWPBDx+Sg3rOZdCELIA3ZmNoWAuxaMOT7aWtGRSYkQxw==",
+			"version": "6.9.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.9.1.tgz",
+			"integrity": "sha512-38IxvKB6NAne3g/+MyXMs2Cda/Sz+CEpmm+KLGEM8hx/CvnSRuw51i8ukfwB/B/sESdeTGet1NH1Wj7I0YXswg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.9.0",
-				"@typescript-eslint/visitor-keys": "6.9.0"
+				"@typescript-eslint/types": "6.9.1",
+				"@typescript-eslint/visitor-keys": "6.9.1"
 			},
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -2065,13 +2066,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.9.0.tgz",
-			"integrity": "sha512-XXeahmfbpuhVbhSOROIzJ+b13krFmgtc4GlEuu1WBT+RpyGPIA4Y/eGnXzjbDj5gZLzpAXO/sj+IF/x2GtTMjQ==",
+			"version": "6.9.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.9.1.tgz",
+			"integrity": "sha512-eh2oHaUKCK58qIeYp19F5V5TbpM52680sB4zNSz29VBQPTWIlE/hCj5P5B1AChxECe/fmZlspAWFuRniep1Skg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "6.9.0",
-				"@typescript-eslint/utils": "6.9.0",
+				"@typescript-eslint/typescript-estree": "6.9.1",
+				"@typescript-eslint/utils": "6.9.1",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^1.0.1"
 			},
@@ -2092,9 +2093,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.9.0.tgz",
-			"integrity": "sha512-+KB0lbkpxBkBSiVCuQvduqMJy+I1FyDbdwSpM3IoBS7APl4Bu15lStPjgBIdykdRqQNYqYNMa8Kuidax6phaEw==",
+			"version": "6.9.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.9.1.tgz",
+			"integrity": "sha512-BUGslGOb14zUHOUmDB2FfT6SI1CcZEJYfF3qFwBeUrU6srJfzANonwRYHDpLBuzbq3HaoF2XL2hcr01c8f8OaQ==",
 			"dev": true,
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -2105,13 +2106,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.9.0.tgz",
-			"integrity": "sha512-NJM2BnJFZBEAbCfBP00zONKXvMqihZCrmwCaik0UhLr0vAgb6oguXxLX1k00oQyD+vZZ+CJn3kocvv2yxm4awQ==",
+			"version": "6.9.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.9.1.tgz",
+			"integrity": "sha512-U+mUylTHfcqeO7mLWVQ5W/tMLXqVpRv61wm9ZtfE5egz7gtnmqVIw9ryh0mgIlkKk9rZLY3UHygsBSdB9/ftyw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.9.0",
-				"@typescript-eslint/visitor-keys": "6.9.0",
+				"@typescript-eslint/types": "6.9.1",
+				"@typescript-eslint/visitor-keys": "6.9.1",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -2132,17 +2133,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.9.0.tgz",
-			"integrity": "sha512-5Wf+Jsqya7WcCO8me504FBigeQKVLAMPmUzYgDbWchINNh1KJbxCgVya3EQ2MjvJMVeXl3pofRmprqX6mfQkjQ==",
+			"version": "6.9.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.9.1.tgz",
+			"integrity": "sha512-L1T0A5nFdQrMVunpZgzqPL6y2wVreSyHhKGZryS6jrEN7bD9NplVAyMryUhXsQ4TWLnZmxc2ekar/lSGIlprCA==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
 				"@types/json-schema": "^7.0.12",
 				"@types/semver": "^7.5.0",
-				"@typescript-eslint/scope-manager": "6.9.0",
-				"@typescript-eslint/types": "6.9.0",
-				"@typescript-eslint/typescript-estree": "6.9.0",
+				"@typescript-eslint/scope-manager": "6.9.1",
+				"@typescript-eslint/types": "6.9.1",
+				"@typescript-eslint/typescript-estree": "6.9.1",
 				"semver": "^7.5.4"
 			},
 			"engines": {
@@ -2157,12 +2158,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.9.0.tgz",
-			"integrity": "sha512-dGtAfqjV6RFOtIP8I0B4ZTBRrlTT8NHHlZZSchQx3qReaoDeXhYM++M4So2AgFK9ZB0emRPA6JI1HkafzA2Ibg==",
+			"version": "6.9.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.9.1.tgz",
+			"integrity": "sha512-MUaPUe/QRLEffARsmNfmpghuQkW436DvESW+h+M52w0coICHRfD6Np9/K6PdACwnrq1HmuLl+cSPZaJmeVPkSw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.9.0",
+				"@typescript-eslint/types": "6.9.1",
 				"eslint-visitor-keys": "^3.4.1"
 			},
 			"engines": {
@@ -2349,9 +2350,9 @@
 			"integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
 		},
 		"node_modules/acorn": {
-			"version": "8.10.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-			"integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+			"version": "8.11.2",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
+			"integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -2369,9 +2370,9 @@
 			}
 		},
 		"node_modules/acorn-walk": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.0.tgz",
+			"integrity": "sha512-FS7hV565M5l1R08MXqo8odwMTB02C2UqzB17RVgu9EyuYFBqJZ3/ZY97sQD5FewVu1UyDFc1yztUDrAwT0EypA==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.4.0"
@@ -2692,9 +2693,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001554",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001554.tgz",
-			"integrity": "sha512-A2E3U//MBwbJVzebddm1YfNp7Nud5Ip+IPn4BozBmn4KqVX7AvluoIDFWjsv5OkGnKUXQVmMSoMKLa3ScCblcQ==",
+			"version": "1.0.30001559",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001559.tgz",
+			"integrity": "sha512-cPiMKZgqgkg5LY3/ntGeLFUpi6tzddBNS58A4tnTgQw1zON7u2sZMU7SzOeVH4tj20++9ggL+V6FDOFMTaFFYA==",
 			"dev": true,
 			"funding": [
 				{
@@ -3341,9 +3342,9 @@
 			"integrity": "sha512-ilkD8YEnnGh1zJ240uJsW7AzE+2qpbOUYjacomn3AvJ6J4JhKGSZ2nh4wUIXPZrEPppaCLx5jFe8T89Rk8tQ7w=="
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.566",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.566.tgz",
-			"integrity": "sha512-mv+fAy27uOmTVlUULy15U3DVJ+jg+8iyKH1bpwboCRhtDC69GKf1PPTZvEIhCyDr81RFqfxZJYrbgp933a1vtg==",
+			"version": "1.4.574",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.574.tgz",
+			"integrity": "sha512-bg1m8L0n02xRzx4LsTTMbBPiUd9yIR+74iPtS/Ao65CuXvhVZHP0ym1kSdDG3yHFDXqHQQBKujlN1AQ8qZnyFg==",
 			"dev": true
 		},
 		"node_modules/emoji-regex": {
@@ -3525,35 +3526,6 @@
 				}
 			}
 		},
-		"node_modules/eslint-plugin-svelte/node_modules/postcss-load-config": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.4.tgz",
-			"integrity": "sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==",
-			"dev": true,
-			"dependencies": {
-				"lilconfig": "^2.0.5",
-				"yaml": "^1.10.2"
-			},
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/postcss/"
-			},
-			"peerDependencies": {
-				"postcss": ">=8.0.9",
-				"ts-node": ">=9.0.0"
-			},
-			"peerDependenciesMeta": {
-				"postcss": {
-					"optional": true
-				},
-				"ts-node": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/eslint-plugin-svelte/node_modules/postcss-selector-parser": {
 			"version": "6.0.13",
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
@@ -3565,15 +3537,6 @@
 			},
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/eslint-plugin-svelte/node_modules/yaml": {
-			"version": "1.10.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/eslint-scope": {
@@ -4283,9 +4246,9 @@
 			}
 		},
 		"node_modules/jiti": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/jiti/-/jiti-1.20.0.tgz",
-			"integrity": "sha512-3TV69ZbrvV6U5DfQimop50jE9Dl6J8O1ja1dvBbMba/sZ3YBEQqJ2VZRoQPVnhlzjNtU1vaXRZVrVjU4qtm8yA==",
+			"version": "1.21.0",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
+			"integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
 			"dev": true,
 			"bin": {
 				"jiti": "bin/jiti.js"
@@ -4527,9 +4490,9 @@
 			}
 		},
 		"node_modules/marked": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-9.1.3.tgz",
-			"integrity": "sha512-XPU/J7GzU/n4voCSw1VYggtr3W5C2OeGkwEbe5PIQdA8thaie2Qw+fig6iNidKNDokTNcyR4OE9fMK14P6rqPg==",
+			"version": "9.1.5",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-9.1.5.tgz",
+			"integrity": "sha512-14QG3shv8Kg/xc0Yh6TNkMj90wXH9mmldi5941I2OevfJ/FQAFLEwtwU2/FfgSAOMlWHrEukWSGQf8MiVYNG2A==",
 			"bin": {
 				"marked": "bin/marked.js"
 			},
@@ -5105,16 +5068,16 @@
 			}
 		},
 		"node_modules/postcss-load-config": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.1.tgz",
-			"integrity": "sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.4.tgz",
+			"integrity": "sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==",
 			"dev": true,
 			"dependencies": {
 				"lilconfig": "^2.0.5",
-				"yaml": "^2.1.1"
+				"yaml": "^1.10.2"
 			},
 			"engines": {
-				"node": ">= 14"
+				"node": ">= 10"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -5275,8 +5238,6 @@
 			"resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.0.3.tgz",
 			"integrity": "sha512-dLhieh4obJEK1hnZ6koxF+tMUrZbV5YGvRpf2+OADyanjya5j0z1Llo8iGwiHmFWZVG/hLEw/AJD5chXd9r3XA==",
 			"dev": true,
-			"optional": true,
-			"peer": true,
 			"peerDependencies": {
 				"prettier": "^3.0.0",
 				"svelte": "^3.2.0 || ^4.0.0-next.0"
@@ -5365,9 +5326,9 @@
 			"integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
 		},
 		"node_modules/punycode": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-			"integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
 			"engines": {
 				"node": ">=6"
 			}
@@ -5634,9 +5595,9 @@
 			}
 		},
 		"node_modules/sass": {
-			"version": "1.69.4",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.69.4.tgz",
-			"integrity": "sha512-+qEreVhqAy8o++aQfCJwp0sklr2xyEzkm9Pp/Igu9wNPoe7EZEQ8X/MBvvXggI2ql607cxKg/RKOwDj6pp2XDA==",
+			"version": "1.69.5",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.69.5.tgz",
+			"integrity": "sha512-qg2+UCJibLr2LCVOt3OlPhr/dqVHWOa9XtZf2OjbLs/T4VPSJ00udtgJxH3neXZm+QqX8B+3cU7RaLqp1iVfcQ==",
 			"devOptional": true,
 			"dependencies": {
 				"chokidar": ">=3.0.0 <4.0.0",
@@ -6276,6 +6237,35 @@
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/tailwindcss/node_modules/postcss-load-config": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.1.tgz",
+			"integrity": "sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==",
+			"dev": true,
+			"dependencies": {
+				"lilconfig": "^2.0.5",
+				"yaml": "^2.1.1"
+			},
+			"engines": {
+				"node": ">= 14"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/postcss/"
+			},
+			"peerDependencies": {
+				"postcss": ">=8.0.9",
+				"ts-node": ">=9.0.0"
+			},
+			"peerDependenciesMeta": {
+				"postcss": {
+					"optional": true
+				},
+				"ts-node": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/tailwindcss/node_modules/postcss-selector-parser": {
 			"version": "6.0.13",
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
@@ -6287,6 +6277,15 @@
 			},
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/tailwindcss/node_modules/yaml": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.3.tgz",
+			"integrity": "sha512-zw0VAJxgeZ6+++/su5AFoqBbZbrEakwu+X0M5HmcwUiBL7AzcuPKjj5we4xfQLp78LkEMpD0cOnUhmgOVy3KdQ==",
+			"dev": true,
+			"engines": {
+				"node": ">= 14"
 			}
 		},
 		"node_modules/text-table": {
@@ -7321,12 +7320,12 @@
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		},
 		"node_modules/yaml": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.3.tgz",
-			"integrity": "sha512-zw0VAJxgeZ6+++/su5AFoqBbZbrEakwu+X0M5HmcwUiBL7AzcuPKjj5we4xfQLp78LkEMpD0cOnUhmgOVy3KdQ==",
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
 			"dev": true,
 			"engines": {
-				"node": ">= 14"
+				"node": ">= 6"
 			}
 		},
 		"node_modules/yargs": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,7 @@
 		"eslint-plugin-svelte": "^2.33.0",
 		"postcss": "^8.4.29",
 		"prettier": "^3.0.3",
+		"prettier-plugin-svelte": "^3.0.3",
 		"prettier-plugin-tailwindcss": "^0.5.6",
 		"shx": "^0.3.4",
 		"simple-svelte-autocomplete": "^2.5.2",


### PR DESCRIPTION
# Description

This did not work as expected without the package. To reproduce:

<img width="1017" alt="image" src="https://github.com/zeno-ml/zeno-hub/assets/5690524/6d277491-dae8-45fe-9caa-d30572909d57">
