### PR TITLE
refactor: move instance-views into hub

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,16 +11,19 @@
 				"@amplitude/analytics-browser": "^2.3.1",
 				"@auth/core": "^0.18.0",
 				"@auth/sveltekit": "^0.3.11",
+				"@codemirror/lang-json": "^6.0.1",
 				"@mdi/js": "^7.3.67",
 				"@smui/fab": "^7.0.0-beta.15",
-				"@zeno-ml/zeno-instance-views": "^0.0.8",
+				"ajv": "^8.12.0",
 				"amazon-cognito-identity-js": "^6.3.6",
 				"d3-array": "^3.2.4",
 				"d3-interpolate": "^3.0.1",
 				"d3-scale": "^4.0.2",
 				"isomorphic-dompurify": "^1.8.0",
 				"marked": "^9.1.3",
+				"svelte-codemirror-editor": "^1.1.0",
 				"svelte-dnd-action": "^0.9.22",
+				"svelte-highlight": "^7.4.1",
 				"svelte-vega": "^2.1.0",
 				"vega": "^5.25.0",
 				"vega-lite": "^5.9.3"
@@ -53,6 +56,7 @@
 				"prettier": "^3.0.3",
 				"prettier-plugin-svelte": "^3.0.3",
 				"prettier-plugin-tailwindcss": "^0.5.6",
+				"publint": "^0.2.5",
 				"shx": "^0.3.4",
 				"simple-svelte-autocomplete": "^2.5.2",
 				"smui-theme": "^7.0.0-beta.8",
@@ -60,6 +64,7 @@
 				"svelte": "^4.2.2",
 				"svelte-check": "^3.5.2",
 				"tailwindcss": "^3.3.4",
+				"ts-json-schema-generator": "^1.4.0",
 				"tslib": "^2.6.2",
 				"typescript": "^5.2.2",
 				"vite": "^4.4.9",
@@ -712,6 +717,28 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/@eslint/eslintrc/node_modules/ajv": {
+			"version": "6.12.6",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"dev": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true
+		},
 		"node_modules/@eslint/js": {
 			"version": "8.53.0",
 			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.53.0.tgz",
@@ -720,11 +747,6 @@
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
-		},
-		"node_modules/@exodus/schemasafe": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.3.0.tgz",
-			"integrity": "sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw=="
 		},
 		"node_modules/@fastify/busboy": {
 			"version": "2.0.0",
@@ -2327,23 +2349,6 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
-		"node_modules/@zeno-ml/zeno-instance-views": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/@zeno-ml/zeno-instance-views/-/zeno-instance-views-0.0.8.tgz",
-			"integrity": "sha512-Z3puURjx3AsIDDSw2bSMakvKaLrvXhqJik3iV6h6P3n1bObBrjY8MyJb3MPkT6GakwaOKjsWs4tih9/kqZnmmA==",
-			"dependencies": {
-				"@codemirror/lang-json": "^6.0.1",
-				"@exodus/schemasafe": "^1.3.0",
-				"@mdi/js": "^7.3.67",
-				"isomorphic-dompurify": "^1.9.0",
-				"marked": "^9.1.2",
-				"svelte-codemirror-editor": "^1.1.0",
-				"svelte-highlight": "^7.4.1"
-			},
-			"peerDependencies": {
-				"svelte": "^4.2.2"
-			}
-		},
 		"node_modules/abab": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -2390,14 +2395,13 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-			"dev": true,
+			"version": "8.12.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.4.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2",
 				"uri-js": "^4.2.2"
 			},
 			"funding": {
@@ -3567,6 +3571,28 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/eslint/node_modules/ajv": {
+			"version": "6.12.6",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"dev": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/eslint/node_modules/json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true
+		},
 		"node_modules/esm-env": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.0.0.tgz",
@@ -4045,6 +4071,39 @@
 				"node": ">= 4"
 			}
 		},
+		"node_modules/ignore-walk": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-5.0.1.tgz",
+			"integrity": "sha512-yemi4pMf51WKT7khInJqAvsIGzoqYXblnsz0ql8tM+yi1EKYTY1evX4NAbJrLL/Aanr2HyZeluqU+Oi7MGHokw==",
+			"dev": true,
+			"dependencies": {
+				"minimatch": "^5.0.1"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/ignore-walk/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/ignore-walk/node_modules/minimatch": {
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/immutable": {
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
@@ -4327,10 +4386,9 @@
 			"dev": true
 		},
 		"node_modules/json-schema-traverse": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
@@ -4342,6 +4400,18 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz",
 			"integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA=="
+		},
+		"node_modules/json5": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+			"dev": true,
+			"bin": {
+				"json5": "lib/cli.js"
+			},
+			"engines": {
+				"node": ">=6"
+			}
 		},
 		"node_modules/jsonc-parser": {
 			"version": "3.2.0",
@@ -4724,6 +4794,45 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npm-bundled": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-2.0.1.tgz",
+			"integrity": "sha512-gZLxXdjEzE/+mOstGDqR6b0EkhJ+kM6fxM6vUuckuctuVPh80Q6pw/rSZj9s4Gex9GxWtIicO1pc8DB9KZWudw==",
+			"dev": true,
+			"dependencies": {
+				"npm-normalize-package-bin": "^2.0.0"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/npm-normalize-package-bin": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-2.0.0.tgz",
+			"integrity": "sha512-awzfKUO7v0FscrSpRoogyNm0sajikhBWpU0QMrW09AMi9n1PoKU6WaIqUzuJSQnpciZZmJ/jMZ2Egfmb/9LiWQ==",
+			"dev": true,
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/npm-packlist": {
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-5.1.3.tgz",
+			"integrity": "sha512-263/0NGrn32YFYi4J533qzrQ/krmmrWwhKkzwTuM4f/07ug51odoaNjUexxO4vxlzURHcmYMH1QjvHjsNDKLVg==",
+			"dev": true,
+			"dependencies": {
+				"glob": "^8.0.1",
+				"ignore-walk": "^5.0.1",
+				"npm-bundled": "^2.0.0",
+				"npm-normalize-package-bin": "^2.0.0"
+			},
+			"bin": {
+				"npm-packlist": "bin/index.js"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/nwsapi": {
@@ -5325,6 +5434,26 @@
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
 			"integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
 		},
+		"node_modules/publint": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/publint/-/publint-0.2.5.tgz",
+			"integrity": "sha512-eoQiP0WXkxkpth1fMLoS1I/6BQoxKNZxTAAnFjPgURFrJulC5D5Uifk49a9kfNCYmcza9E/ZkbFhQQdjkmKAbg==",
+			"dev": true,
+			"dependencies": {
+				"npm-packlist": "^5.1.3",
+				"picocolors": "^1.0.0",
+				"sade": "^1.8.1"
+			},
+			"bin": {
+				"publint": "lib/cli.js"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://bjornlu.com/sponsor"
+			}
+		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5401,6 +5530,14 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -5543,6 +5680,15 @@
 			},
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/safe-stable-stringify": {
+			"version": "2.4.3",
+			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+			"integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/safer-buffer": {
@@ -6429,6 +6575,36 @@
 			"integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
 			"dev": true
 		},
+		"node_modules/ts-json-schema-generator": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/ts-json-schema-generator/-/ts-json-schema-generator-1.4.0.tgz",
+			"integrity": "sha512-wm8vyihmGgYpxrqRshmYkWGNwEk+sf3xV2rUgxv8Ryeh7bSpMO7pZQOht+2rS002eDkFTxR7EwRPXVzrS0WJTg==",
+			"dev": true,
+			"dependencies": {
+				"@types/json-schema": "^7.0.12",
+				"commander": "^11.0.0",
+				"glob": "^8.0.3",
+				"json5": "^2.2.3",
+				"normalize-path": "^3.0.0",
+				"safe-stable-stringify": "^2.4.3",
+				"typescript": "~5.2.2"
+			},
+			"bin": {
+				"ts-json-schema-generator": "bin/ts-json-schema-generator"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/ts-json-schema-generator/node_modules/commander": {
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+			"integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=16"
+			}
+		},
 		"node_modules/tslib": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
@@ -6549,7 +6725,6 @@
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-			"dev": true,
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,8 @@
 		"lint": "prettier --check ./**/*.{js,ts,cjs,json,svelte,html,postcss,css} && eslint .",
 		"format": "prettier --write ./**/*.{js,ts,cjs,json,svelte,html,postcss,css}",
 		"smui-theme": "smui-theme compile static/smui.css -i src/theme",
-		"generate-api": "npx openapi-typescript-codegen --input http://127.0.0.1:8000/api/openapi.json --output ./src/lib/zenoapi --name ZenoClient; npx prettier -w ./src/lib/zenoapi "
+		"generate-api": "npx openapi-typescript-codegen --input http://127.0.0.1:8000/api/openapi.json --output ./src/lib/zenoapi --name ZenoClient; npx prettier -w ./src/lib/zenoapi",
+		"generateSchema": "ts-json-schema-generator --path ./src/lib/instance-views/schema.ts --out ./src/lib/instance-views/schema.json"
 	},
 	"devDependencies": {
 		"@formkit/auto-animate": "^0.8.0",
@@ -41,7 +42,9 @@
 		"postcss": "^8.4.29",
 		"prettier": "^3.0.3",
 		"prettier-plugin-svelte": "^3.0.3",
+		"publint": "^0.2.5",
 		"prettier-plugin-tailwindcss": "^0.5.6",
+		"ts-json-schema-generator": "^1.4.0",
 		"shx": "^0.3.4",
 		"simple-svelte-autocomplete": "^2.5.2",
 		"smui-theme": "^7.0.0-beta.8",
@@ -60,8 +63,11 @@
 		"@auth/sveltekit": "^0.3.11",
 		"@mdi/js": "^7.3.67",
 		"@smui/fab": "^7.0.0-beta.15",
-		"@zeno-ml/zeno-instance-views": "^0.0.10",
 		"amazon-cognito-identity-js": "^6.3.6",
+		"@codemirror/lang-json": "^6.0.1",
+		"ajv": "^8.12.0",
+		"svelte-codemirror-editor": "^1.1.0",
+		"svelte-highlight": "^7.4.1",
 		"d3-array": "^3.2.4",
 		"d3-interpolate": "^3.0.1",
 		"d3-scale": "^4.0.2",

--- a/frontend/src/lib/components/instances/ComparisonView.svelte
+++ b/frontend/src/lib/components/instances/ComparisonView.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { instanceOfFilterPredicate } from '$lib/api/slice';
 	import { getFilteredTable } from '$lib/api/table';
+	import InstanceView from '$lib/instance-views/InstanceView.svelte';
 	import {
 		columns,
 		compareSort,
@@ -19,7 +20,6 @@
 	import { Icon, Label } from '@smui/button';
 	import { Pagination } from '@smui/data-table';
 	import IconButton from '@smui/icon-button';
-	import InstanceView from '@zeno-ml/zeno-instance-views';
 	import { getContext } from 'svelte';
 
 	export let modelAResult: Promise<GroupMetric[] | undefined>;

--- a/frontend/src/lib/components/instances/ListView.svelte
+++ b/frontend/src/lib/components/instances/ListView.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { instanceOfFilterPredicate } from '$lib/api/slice';
 	import { getFilteredTable } from '$lib/api/table';
+	import InstanceView from '$lib/instance-views/InstanceView.svelte';
 	import {
 		columns,
 		model,
@@ -16,7 +17,6 @@
 	import { Label } from '@smui/button';
 	import { Pagination } from '@smui/data-table';
 	import IconButton from '@smui/icon-button';
-	import InstanceView from '@zeno-ml/zeno-instance-views';
 	import { getContext } from 'svelte';
 
 	export let numberOfInstances = 0;

--- a/frontend/src/lib/components/instances/TableView.svelte
+++ b/frontend/src/lib/components/instances/TableView.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { instanceOfFilterPredicate } from '$lib/api/slice';
 	import { getFilteredTable } from '$lib/api/table';
+	import InstanceView from '$lib/instance-views/InstanceView.svelte';
 	import {
 		columns,
 		editTag,
@@ -20,7 +21,6 @@
 	import Checkbox from '@smui/checkbox';
 	import { Pagination } from '@smui/data-table';
 	import IconButton from '@smui/icon-button';
-	import InstanceView from '@zeno-ml/zeno-instance-views';
 	import { getContext } from 'svelte';
 
 	export let numberOfInstances = 0;

--- a/frontend/src/lib/components/report/elements/SliceElement.svelte
+++ b/frontend/src/lib/components/report/elements/SliceElement.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
+	import InstanceView from '$lib/instance-views/InstanceView.svelte';
 	import type { URLParams } from '$lib/util/util';
 	import type {
 		ReportElement,
@@ -11,7 +12,6 @@
 	import { mdiChevronLeft, mdiChevronRight } from '@mdi/js';
 	import { Icon } from '@smui/button';
 	import Button from '@smui/button/';
-	import InstanceView from '@zeno-ml/zeno-instance-views';
 	import { getContext } from 'svelte';
 
 	export let element: ReportElement;

--- a/frontend/src/lib/instance-views/Error.svelte
+++ b/frontend/src/lib/instance-views/Error.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	export let type: string;
+	export let message: string | undefined;
+</script>
+
+<div class="flex flex-col overflow-auto text-red">
+	<span class="font-bold">{type}</span>
+	{#if message}
+		<pre>
+{message}
+		</pre>
+	{/if}
+</div>

--- a/frontend/src/lib/instance-views/Error.svelte
+++ b/frontend/src/lib/instance-views/Error.svelte
@@ -3,7 +3,7 @@
 	export let message: string | undefined;
 </script>
 
-<div class="flex flex-col overflow-auto text-red">
+<div class="text-red flex flex-col overflow-auto">
 	<span class="font-bold">{type}</span>
 	{#if message}
 		<pre>

--- a/frontend/src/lib/instance-views/InstanceView.svelte
+++ b/frontend/src/lib/instance-views/InstanceView.svelte
@@ -1,0 +1,113 @@
+<script lang="ts">
+	import Error from '$lib/instance-views/Error.svelte';
+	import { elementMap, isComplexElement } from '$lib/instance-views/resolve.js';
+	import type { ViewSchema } from '$lib/instance-views/schema';
+	import schema from '$lib/instance-views/schema.json';
+	import Ajv from 'ajv';
+
+	export let view: string;
+	export let entry: Record<string, unknown>;
+	export let dataColumn: string | undefined | null;
+	export let labelColumn: string | undefined | null;
+	export let modelColumn: string | undefined | null;
+
+	const ajv = new Ajv();
+	ajv.addSchema(schema);
+	const validate = ajv.getSchema('#/definitions/ViewSchema');
+
+	let viewSpec: ViewSchema;
+	let JSONParseError = '';
+	let schemaValidationError = '';
+
+	$: try {
+		viewSpec = JSON.parse(view);
+		JSONParseError = '';
+		if (validate) {
+			if (!validate(viewSpec)) {
+				schemaValidationError = ajv.errorsText(validate.errors, {
+					dataVar: 'View Specification',
+					separator: '\n'
+				});
+			} else {
+				schemaValidationError = '';
+			}
+		}
+	} catch (error) {
+		JSONParseError = error as string;
+	}
+</script>
+
+{#if JSONParseError}
+	<Error type="Invalid JSON for View Specification" message={JSONParseError} />
+{:else if schemaValidationError}
+	<Error type="Invalid View Specification" message={schemaValidationError} />
+{:else if viewSpec.displayType === 'table'}
+	<table class="overflow-x-auto break-words rounded border border-grey-lighter p-4">
+		{#if dataColumn && entry[dataColumn] !== undefined && viewSpec.data}
+			<svelte:component
+				this={elementMap[viewSpec.data.type]}
+				spec={viewSpec.data}
+				data={typeof entry[dataColumn] === 'object'
+					? JSON.stringify(entry[dataColumn])
+					: entry[dataColumn]}
+			/>
+		{/if}
+		{#if labelColumn && entry[labelColumn] !== undefined && viewSpec.label}
+			<svelte:component
+				this={elementMap[viewSpec.label.type]}
+				spec={viewSpec.label}
+				data={typeof entry[labelColumn] === 'object'
+					? JSON.stringify(entry[labelColumn])
+					: entry[labelColumn]}
+			/>
+		{/if}
+		{#if modelColumn && entry[modelColumn] !== undefined && viewSpec.output}
+			<svelte:component
+				this={elementMap[viewSpec.output.type]}
+				spec={viewSpec.output}
+				data={typeof entry[modelColumn] === 'object'
+					? JSON.stringify(entry[modelColumn])
+					: entry[modelColumn]}
+			/>
+		{/if}
+	</table>
+{:else}
+	<div class="overflow-x-auto break-words rounded border border-grey-lighter p-4">
+		{#if dataColumn && entry[dataColumn] !== undefined && viewSpec.data}
+			<div class="flex {isComplexElement(viewSpec.data.type) ? 'flex-col' : 'flex-row'}">
+				<svelte:component
+					this={elementMap[viewSpec.data.type]}
+					spec={viewSpec.data}
+					data={typeof entry[dataColumn] === 'object'
+						? JSON.stringify(entry[dataColumn])
+						: entry[dataColumn]}
+				/>
+			</div>
+		{/if}
+		{#if labelColumn && entry[labelColumn] !== undefined && viewSpec.label}
+			<div class="flex {isComplexElement(viewSpec.label.type) ? 'flex-col' : 'flex-row'} mt-2">
+				<span class="pr-2 font-semibold">label: </span>
+				<svelte:component
+					this={elementMap[viewSpec.label.type]}
+					spec={viewSpec.label}
+					data={typeof entry[labelColumn] === 'object'
+						? JSON.stringify(entry[labelColumn])
+						: entry[labelColumn]}
+				/>
+			</div>
+		{/if}
+		{#if modelColumn && entry[modelColumn] !== undefined && viewSpec.output}
+			<hr class="-mx-4 my-4 text-grey-lighter" />
+			<div class="flex {isComplexElement(viewSpec.output.type) ? 'flex-col' : 'flex-row'}">
+				<span class="pr-2 font-semibold">output: </span>
+				<svelte:component
+					this={elementMap[viewSpec.output.type]}
+					spec={viewSpec.output}
+					data={typeof entry[modelColumn] === 'object'
+						? JSON.stringify(entry[modelColumn])
+						: entry[modelColumn]}
+				/>
+			</div>
+		{/if}
+	</div>
+{/if}

--- a/frontend/src/lib/instance-views/elements/Audio.svelte
+++ b/frontend/src/lib/instance-views/elements/Audio.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	export let data: string;
+</script>
+
+<audio controls src={data} class="my-2">
+	<source src={data} type={'audio/' + `${data}`.split('.').at(-1)} />
+</audio>

--- a/frontend/src/lib/instance-views/elements/Code.svelte
+++ b/frontend/src/lib/instance-views/elements/Code.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import { HighlightAuto } from 'svelte-highlight';
+	import github from 'svelte-highlight/styles/github';
+
+	export let data: string;
+</script>
+
+<svelte:head>
+	<!-- eslint-disable -->
+	{@html github}
+</svelte:head>
+
+<HighlightAuto code={data} />

--- a/frontend/src/lib/instance-views/elements/Image.svelte
+++ b/frontend/src/lib/instance-views/elements/Image.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+	import type { ImageView } from '$lib/instance-views/schema.js';
+	import { mdiArrowExpand, mdiClose } from '@mdi/js';
+
+	export let data: string;
+	export let spec: ImageView;
+
+	const widthMap = {
+		small: 'w-48',
+		medium: 'w-64',
+		large: 'w-96',
+		full: 'w-full'
+	};
+
+	let showPopup = false;
+</script>
+
+<div class="group relative">
+	<img
+		class={spec.maxWidth ? widthMap[spec.maxWidth] : ''}
+		src={data}
+		alt="Image thumbnail for instance {data}"
+	/>
+	<button
+		class="absolute right-0 top-0 hidden rounded-md p-1 hover:bg-primary-ligther group-hover:inline"
+		on:click={(e) => {
+			showPopup = true;
+			e.preventDefault();
+		}}
+	>
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-6 fill-grey-darker">
+			<path d={mdiArrowExpand} />
+		</svg>
+	</button>
+</div>
+
+{#if showPopup}
+	<div
+		id="fullscreenModal"
+		class="bg-gray-500 fixed inset-0 z-50 flex items-center justify-center bg-opacity-75 p-4"
+	>
+		<div class="relative w-full max-w-2xl rounded-lg bg-white p-6 shadow-xl">
+			<button
+				on:click={() => (showPopup = false)}
+				class="absolute right-0 top-0 mr-4 mt-4 rounded-md p-1 hover:bg-primary-ligther"
+			>
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-6 fill-grey-darker">
+					<path d={mdiClose} />
+				</svg>
+			</button>
+			<img src={data} alt="Image thumbnail for instance {data}" />
+		</div>
+	</div>
+{/if}

--- a/frontend/src/lib/instance-views/elements/List.svelte
+++ b/frontend/src/lib/instance-views/elements/List.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+	import { elementMap } from '$lib/instance-views/resolve.js';
+	import type { ListView, ViewUnion } from '$lib/instance-views/schema.js';
+	import { mdiChevronDown, mdiChevronLeft, mdiChevronRight, mdiChevronUp } from '@mdi/js';
+	import Error from '../Error.svelte';
+
+	export let data: string;
+	export let spec: ListView;
+
+	let jsonData: Array<ViewUnion> | undefined = undefined;
+	let errorMessage: string | undefined = undefined;
+
+	$: showAll = jsonData !== undefined ? jsonData.length <= 5 : false;
+
+	$: try {
+		jsonData = JSON.parse(data);
+		errorMessage = undefined;
+		if (!Array.isArray(jsonData)) {
+			jsonData = undefined;
+			errorMessage = 'Data is not an array';
+		}
+	} catch (error) {
+		jsonData = undefined;
+		errorMessage = error as string;
+	}
+
+	$: shownDocs =
+		jsonData === undefined
+			? []
+			: showAll || spec.collapsible === undefined
+			? jsonData
+			: spec.collapsible === 'bottom'
+			? jsonData.slice(0, 4)
+			: jsonData.slice(-4);
+</script>
+
+{#if jsonData === undefined}
+	<Error type="Incorrect Data" message={errorMessage} />
+{:else}
+	<div class="flex {spec.horizontal ? 'flex-row' : 'flex-col'}">
+		{#if spec.collapsible === 'top' && jsonData.length > 4}
+			<button
+				class="bg-transparent flex cursor-pointer items-center self-center rounded-2xl p-1 hover:bg-grey-lighter"
+				on:click={() => (showAll = !showAll)}
+			>
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-6 fill-grey-darker">
+					{#if spec.horizontal}
+						<path d={showAll ? mdiChevronLeft : mdiChevronRight} />
+					{:else}
+						<path d={showAll ? mdiChevronDown : mdiChevronUp} />
+					{/if}
+				</svg>
+				<span class="pr-1">Show {showAll ? 'Less' : 'All'}</span>
+			</button>
+		{/if}
+		{#each shownDocs as element (element)}
+			<div
+				class="rounded-sm {spec.pad ? 'p-3' : ''} {spec.border
+					? 'border border-grey-lighter'
+					: ''} m-1"
+			>
+				{#if spec.elements && spec.elements.type && typeof spec.elements.type === 'string'}
+					<svelte:component
+						this={elementMap[spec.elements.type]}
+						spec={spec.elements}
+						data={typeof element === 'object' ? JSON.stringify(element) : element}
+					/>
+				{:else}
+					<Error type="Incorrect View Specification" message="No element type specified" />
+				{/if}
+			</div>
+		{/each}
+		{#if spec.collapsible === 'bottom'}
+			<button
+				class="bg-transparent flex cursor-pointer items-center self-center rounded-2xl p-1 hover:bg-grey-lighter"
+				on:click={() => (showAll = !showAll)}
+			>
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-6 fill-grey-darker">
+					{#if spec.horizontal}
+						<path d={showAll ? mdiChevronLeft : mdiChevronRight} />
+					{:else}
+						<path d={showAll ? mdiChevronDown : mdiChevronUp} />
+					{/if}
+				</svg>
+				<span class="pr-1">Show {showAll ? 'Less' : 'All'}</span>
+			</button>
+		{/if}
+	</div>
+{/if}

--- a/frontend/src/lib/instance-views/elements/Markdown.svelte
+++ b/frontend/src/lib/instance-views/elements/Markdown.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import purify from 'isomorphic-dompurify';
+	import { parse } from 'marked';
+
+	export let data: string;
+
+	const renderedText = purify.sanitize(parse(data));
+</script>
+
+<article class="[&_a]:break-word prose max-w-none [&_p]:whitespace-pre-wrap">
+	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+	{@html renderedText}
+</article>

--- a/frontend/src/lib/instance-views/elements/Message.svelte
+++ b/frontend/src/lib/instance-views/elements/Message.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+	import { elementMap } from '$lib/instance-views/resolve.js';
+	import type { MessageView } from '$lib/instance-views/schema.js';
+	import Error from '../Error.svelte';
+
+	export let data: string;
+	export let spec: MessageView;
+
+	const type = elementMap[spec.content.type as string];
+
+	let role: string | undefined = undefined;
+	let content = '';
+	let ownMessage = false;
+	let errorMessage: string | undefined = undefined;
+
+	if (spec.plain) {
+		ownMessage = spec.ownMessage === undefined ? role === 'user' : spec.ownMessage;
+		content = data;
+	} else {
+		try {
+			const jsonData = JSON.parse(data);
+			role = jsonData['role'];
+			ownMessage =
+				jsonData['ownMessage'] === undefined ? role === 'user' : jsonData['ownMessage'] === true;
+			content = jsonData['content'];
+			if (typeof content === 'object') content = JSON.stringify(content);
+			errorMessage = undefined;
+		} catch (error) {
+			errorMessage = error as string;
+		}
+	}
+
+	const iconPath = role === undefined ? undefined : getIcon(role);
+
+	function getIcon(role: string): string | undefined {
+		switch (role) {
+			case 'user':
+				// Person Icon
+				return 'M224 256A128 128 0 1 0 224 0a128 128 0 1 0 0 256zm-45.7 48C79.8 304 0 383.8 0 482.3C0 498.7 13.3 512 29.7 512H418.3c16.4 0 29.7-13.3 29.7-29.7C448 383.8 368.2 304 269.7 304H178.3z';
+			case 'assistant':
+				// Robot Icon
+				return 'M320 0c17.7 0 32 14.3 32 32V96H472c39.8 0 72 32.2 72 72V440c0 39.8-32.2 72-72 72H168c-39.8 0-72-32.2-72-72V168c0-39.8 32.2-72 72-72H288V32c0-17.7 14.3-32 32-32zM208 384c-8.8 0-16 7.2-16 16s7.2 16 16 16h32c8.8 0 16-7.2 16-16s-7.2-16-16-16H208zm96 0c-8.8 0-16 7.2-16 16s7.2 16 16 16h32c8.8 0 16-7.2 16-16s-7.2-16-16-16H304zm96 0c-8.8 0-16 7.2-16 16s7.2 16 16 16h32c8.8 0 16-7.2 16-16s-7.2-16-16-16H400zM264 256a40 40 0 1 0 -80 0 40 40 0 1 0 80 0zm152 40a40 40 0 1 0 0-80 40 40 0 1 0 0 80zM48 224H64V416H48c-26.5 0-48-21.5-48-48V272c0-26.5 21.5-48 48-48zm544 0c26.5 0 48 21.5 48 48v96c0 26.5-21.5 48-48 48H576V224h16z';
+			default:
+				return undefined;
+		}
+	}
+</script>
+
+{#if errorMessage !== undefined}
+	<Error type="Incorrect Data" message={errorMessage} />
+{:else if role === 'system'}
+	<p class="m-0">
+		<b>System:</b>
+		<svelte:component this={type} spec={spec.content} data={content} />
+	</p>
+{:else if ownMessage}
+	<div class="relative my-1 flex items-end justify-end">
+		<p
+			class="relative m-0 max-w-[70%] self-start rounded border border-grey-darker bg-background p-2.5 before:absolute before:-right-2.5 before:bottom-0 before:-z-[1] before:h-6 before:w-5 before:rounded-bl-2xl before:bg-grey-darker before:content-[''] after:absolute after:-right-2.5 after:bottom-0 after:-z-[1] after:h-6 after:w-2.5 after:rounded-bl-xl after:bg-background after:content-[''] {spec.highlight
+				? 'border border-primary before:bg-primary'
+				: 'border border-grey-darker'}"
+		>
+			<svelte:component this={type} spec={spec.content} data={content} />
+		</p>
+		{#if iconPath !== undefined}
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				viewBox="0 0 448 512"
+				class="ml-2.5 mt-2 w-3.5 {spec.highlight ? 'fill-primary' : 'fill-grey-darker'}"
+			>
+				<path d={iconPath} />
+			</svg>
+		{:else if role !== undefined}
+			{role}
+		{/if}
+	</div>
+{:else}
+	<div class="relative my-1 flex items-end">
+		{#if iconPath !== undefined}
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				viewBox="0 0 640 512"
+				class={`${spec.highlight ? 'fill-primary' : 'fill-grey-darker'} mr-2.5 mt-2 w-6`}
+			>
+				<path d={iconPath} />
+			</svg>
+		{:else if role !== undefined}
+			{role}
+		{/if}
+		<p
+			class="relative m-0 max-w-[70%] self-start rounded bg-background p-2.5 before:absolute before:-left-2.5 before:bottom-0 before:-z-[1] before:h-6 before:w-5 before:rounded-br-2xl before:bg-grey-darker before:content-[''] after:absolute after:-left-2.5 after:bottom-0 after:-z-[1] after:h-6 after:w-2.5 after:rounded-br-xl after:bg-background after:content-[''] {spec.highlight
+				? 'border border-primary before:bg-primary'
+				: 'border border-grey-darker'}"
+		>
+			<svelte:component this={type} spec={spec.content} data={content} />
+		</p>
+	</div>
+{/if}

--- a/frontend/src/lib/instance-views/elements/SeparatedValues.svelte
+++ b/frontend/src/lib/instance-views/elements/SeparatedValues.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import type { SeparatedValuesView } from '$lib/instance-views/schema.js';
+
+	export let data: string;
+	export let spec: SeparatedValuesView;
+
+	const values = data.split('\n').map((x) => x.split(spec.separator as string));
+</script>
+
+{#each values as value}
+	<div class="table-row {spec.highlight ? 'bg-grey-lighter' : ''}">
+		{#if spec.header !== undefined}
+			<div class="table-cell border border-grey-light p-2">{spec.header}</div>
+		{/if}
+		{#each value as cell}
+			<div class="table-cell border border-grey-light p-2">
+				{cell}
+			</div>
+		{/each}
+	</div>
+{/each}

--- a/frontend/src/lib/instance-views/elements/Text.svelte
+++ b/frontend/src/lib/instance-views/elements/Text.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import type { TextView } from '$lib/instance-views/schema.js';
+
+	export let data: string;
+	export let spec: TextView;
+</script>
+
+{#if spec.label !== undefined}
+	<p class="whitespace-pre-wrap text-grey">
+		<span class="font-semibold">{spec.label}</span>
+		{data}
+	</p>
+{:else}
+	<p class="whitespace-pre-wrap text-grey">
+		{data}
+	</p>
+{/if}

--- a/frontend/src/lib/instance-views/elements/VStack.svelte
+++ b/frontend/src/lib/instance-views/elements/VStack.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+	import { elementMap } from '$lib/instance-views/resolve.js';
+	import type { VStackView, View } from '$lib/instance-views/schema.js';
+	import Error from '../Error.svelte';
+
+	export let data: string;
+	export let spec: VStackView;
+
+	let jsonData: Record<string, View> | undefined = undefined;
+	let errorMessage: string | undefined = undefined;
+
+	$: keys = jsonData ? Object.keys(jsonData) : [];
+	$: try {
+		jsonData = JSON.parse(data);
+		errorMessage = undefined;
+	} catch (error) {
+		jsonData = undefined;
+		errorMessage = error as string;
+	}
+
+	function resolveElementType(key: string) {
+		return elementMap[spec.keys[key].type as string];
+	}
+</script>
+
+{#if jsonData === undefined}
+	<Error type="Incorrect Data" message={errorMessage} />
+{:else}
+	<div class="flex flex-col">
+		{#each keys as key}
+			{#if spec.keys && spec.keys[key] !== undefined && spec.keys[key].type !== undefined}
+				<svelte:component
+					this={resolveElementType(key)}
+					spec={spec.keys[key]}
+					data={typeof jsonData[key] === 'object' ? JSON.stringify(jsonData[key]) : jsonData[key]}
+				/>
+			{/if}
+		{/each}
+	</div>
+{/if}

--- a/frontend/src/lib/instance-views/resolve.ts
+++ b/frontend/src/lib/instance-views/resolve.ts
@@ -1,0 +1,28 @@
+import type { ComponentType } from 'svelte';
+
+import { ViewType } from '$lib/instance-views/schema.js';
+import Audio from './elements/Audio.svelte';
+import Code from './elements/Code.svelte';
+import Image from './elements/Image.svelte';
+import List from './elements/List.svelte';
+import Markdown from './elements/Markdown.svelte';
+import Message from './elements/Message.svelte';
+import SeparatedValues from './elements/SeparatedValues.svelte';
+import Text from './elements/Text.svelte';
+import VStack from './elements/VStack.svelte';
+
+export const elementMap: Record<string, ComponentType> = {
+	[ViewType.text]: Text,
+	[ViewType.vstack]: VStack,
+	[ViewType.list]: List,
+	[ViewType.markdown]: Markdown,
+	[ViewType.image]: Image,
+	[ViewType.audio]: Audio,
+	[ViewType.code]: Code,
+	[ViewType.message]: Message,
+	[ViewType.separatedValues]: SeparatedValues
+};
+
+export function isComplexElement(type: string) {
+	return ['vstack', 'list', 'image', 'audio', 'code', 'message'].includes(type);
+}

--- a/frontend/src/lib/instance-views/schema.json
+++ b/frontend/src/lib/instance-views/schema.json
@@ -1,230 +1,204 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "definitions": {
-    "DisplayType": {
-      "const": "table",
-      "type": "string"
-    },
-    "ImageView": {
-      "additionalProperties": false,
-      "properties": {
-        "maxWidth": {
-          "enum": [
-            "small",
-            "medium",
-            "large",
-            "full"
-          ],
-          "type": "string"
-        },
-        "type": {
-          "const": "image",
-          "type": "string"
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "type": "object"
-    },
-    "ListView": {
-      "additionalProperties": false,
-      "properties": {
-        "border": {
-          "type": "boolean"
-        },
-        "collapsible": {
-          "type": "string"
-        },
-        "elements": {
-          "$ref": "#/definitions/ViewUnion"
-        },
-        "horizontal": {
-          "type": "boolean"
-        },
-        "pad": {
-          "type": "boolean"
-        },
-        "type": {
-          "const": "list",
-          "type": "string"
-        }
-      },
-      "required": [
-        "elements",
-        "type"
-      ],
-      "type": "object"
-    },
-    "MessageView": {
-      "additionalProperties": false,
-      "properties": {
-        "content": {
-          "$ref": "#/definitions/ViewUnion"
-        },
-        "highlight": {
-          "type": "boolean"
-        },
-        "ownMessage": {
-          "type": "boolean"
-        },
-        "plain": {
-          "type": "boolean"
-        },
-        "role": {
-          "type": "string"
-        },
-        "type": {
-          "const": "message",
-          "type": "string"
-        }
-      },
-      "required": [
-        "content",
-        "type"
-      ],
-      "type": "object"
-    },
-    "SeparatedValuesView": {
-      "additionalProperties": false,
-      "properties": {
-        "header": {
-          "type": "string"
-        },
-        "highlight": {
-          "type": "boolean"
-        },
-        "separator": {
-          "type": "string"
-        },
-        "type": {
-          "const": "separatedValues",
-          "type": "string"
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "type": "object"
-    },
-    "TextView": {
-      "additionalProperties": false,
-      "properties": {
-        "label": {
-          "type": "string"
-        },
-        "type": {
-          "const": "text",
-          "type": "string"
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "type": "object"
-    },
-    "VStackView": {
-      "additionalProperties": false,
-      "properties": {
-        "border": {
-          "type": "boolean"
-        },
-        "collapsible": {
-          "type": "string"
-        },
-        "keys": {
-          "additionalProperties": {
-            "$ref": "#/definitions/ViewUnion"
-          },
-          "type": "object"
-        },
-        "pad": {
-          "type": "boolean"
-        },
-        "type": {
-          "const": "vstack",
-          "type": "string"
-        }
-      },
-      "required": [
-        "keys",
-        "type"
-      ],
-      "type": "object"
-    },
-    "View": {
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "$ref": "#/definitions/ViewType"
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "type": "object"
-    },
-    "ViewSchema": {
-      "additionalProperties": false,
-      "properties": {
-        "data": {
-          "$ref": "#/definitions/ViewUnion"
-        },
-        "displayType": {
-          "$ref": "#/definitions/DisplayType"
-        },
-        "label": {
-          "$ref": "#/definitions/ViewUnion"
-        },
-        "output": {
-          "$ref": "#/definitions/ViewUnion"
-        }
-      },
-      "required": [
-        "data",
-        "label",
-        "output"
-      ],
-      "type": "object"
-    },
-    "ViewType": {
-      "enum": [
-        "text",
-        "image",
-        "audio",
-        "code",
-        "markdown",
-        "list",
-        "vstack",
-        "message",
-        "separatedValues"
-      ],
-      "type": "string"
-    },
-    "ViewUnion": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/View"
-        },
-        {
-          "$ref": "#/definitions/TextView"
-        },
-        {
-          "$ref": "#/definitions/ImageView"
-        },
-        {
-          "$ref": "#/definitions/ListView"
-        },
-        {
-          "$ref": "#/definitions/MessageView"
-        },
-        {
-          "$ref": "#/definitions/VStackView"
-        },
-        {
-          "$ref": "#/definitions/SeparatedValuesView"
-        }
-      ]
-    }
-  }
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"DisplayType": {
+			"const": "table",
+			"type": "string"
+		},
+		"ImageView": {
+			"additionalProperties": false,
+			"properties": {
+				"maxWidth": {
+					"enum": ["small", "medium", "large", "full"],
+					"type": "string"
+				},
+				"type": {
+					"const": "image",
+					"type": "string"
+				}
+			},
+			"required": ["type"],
+			"type": "object"
+		},
+		"ListView": {
+			"additionalProperties": false,
+			"properties": {
+				"border": {
+					"type": "boolean"
+				},
+				"collapsible": {
+					"type": "string"
+				},
+				"elements": {
+					"$ref": "#/definitions/ViewUnion"
+				},
+				"horizontal": {
+					"type": "boolean"
+				},
+				"pad": {
+					"type": "boolean"
+				},
+				"type": {
+					"const": "list",
+					"type": "string"
+				}
+			},
+			"required": ["elements", "type"],
+			"type": "object"
+		},
+		"MessageView": {
+			"additionalProperties": false,
+			"properties": {
+				"content": {
+					"$ref": "#/definitions/ViewUnion"
+				},
+				"highlight": {
+					"type": "boolean"
+				},
+				"ownMessage": {
+					"type": "boolean"
+				},
+				"plain": {
+					"type": "boolean"
+				},
+				"role": {
+					"type": "string"
+				},
+				"type": {
+					"const": "message",
+					"type": "string"
+				}
+			},
+			"required": ["content", "type"],
+			"type": "object"
+		},
+		"SeparatedValuesView": {
+			"additionalProperties": false,
+			"properties": {
+				"header": {
+					"type": "string"
+				},
+				"highlight": {
+					"type": "boolean"
+				},
+				"separator": {
+					"type": "string"
+				},
+				"type": {
+					"const": "separatedValues",
+					"type": "string"
+				}
+			},
+			"required": ["type"],
+			"type": "object"
+		},
+		"TextView": {
+			"additionalProperties": false,
+			"properties": {
+				"label": {
+					"type": "string"
+				},
+				"type": {
+					"const": "text",
+					"type": "string"
+				}
+			},
+			"required": ["type"],
+			"type": "object"
+		},
+		"VStackView": {
+			"additionalProperties": false,
+			"properties": {
+				"border": {
+					"type": "boolean"
+				},
+				"collapsible": {
+					"type": "string"
+				},
+				"keys": {
+					"additionalProperties": {
+						"$ref": "#/definitions/ViewUnion"
+					},
+					"type": "object"
+				},
+				"pad": {
+					"type": "boolean"
+				},
+				"type": {
+					"const": "vstack",
+					"type": "string"
+				}
+			},
+			"required": ["keys", "type"],
+			"type": "object"
+		},
+		"View": {
+			"additionalProperties": false,
+			"properties": {
+				"type": {
+					"$ref": "#/definitions/ViewType"
+				}
+			},
+			"required": ["type"],
+			"type": "object"
+		},
+		"ViewSchema": {
+			"additionalProperties": false,
+			"properties": {
+				"data": {
+					"$ref": "#/definitions/ViewUnion"
+				},
+				"displayType": {
+					"$ref": "#/definitions/DisplayType"
+				},
+				"label": {
+					"$ref": "#/definitions/ViewUnion"
+				},
+				"output": {
+					"$ref": "#/definitions/ViewUnion"
+				}
+			},
+			"required": ["data", "label", "output"],
+			"type": "object"
+		},
+		"ViewType": {
+			"enum": [
+				"text",
+				"image",
+				"audio",
+				"code",
+				"markdown",
+				"list",
+				"vstack",
+				"message",
+				"separatedValues"
+			],
+			"type": "string"
+		},
+		"ViewUnion": {
+			"anyOf": [
+				{
+					"$ref": "#/definitions/View"
+				},
+				{
+					"$ref": "#/definitions/TextView"
+				},
+				{
+					"$ref": "#/definitions/ImageView"
+				},
+				{
+					"$ref": "#/definitions/ListView"
+				},
+				{
+					"$ref": "#/definitions/MessageView"
+				},
+				{
+					"$ref": "#/definitions/VStackView"
+				},
+				{
+					"$ref": "#/definitions/SeparatedValuesView"
+				}
+			]
+		}
+	}
 }

--- a/frontend/src/lib/instance-views/schema.json
+++ b/frontend/src/lib/instance-views/schema.json
@@ -1,0 +1,230 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "DisplayType": {
+      "const": "table",
+      "type": "string"
+    },
+    "ImageView": {
+      "additionalProperties": false,
+      "properties": {
+        "maxWidth": {
+          "enum": [
+            "small",
+            "medium",
+            "large",
+            "full"
+          ],
+          "type": "string"
+        },
+        "type": {
+          "const": "image",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "ListView": {
+      "additionalProperties": false,
+      "properties": {
+        "border": {
+          "type": "boolean"
+        },
+        "collapsible": {
+          "type": "string"
+        },
+        "elements": {
+          "$ref": "#/definitions/ViewUnion"
+        },
+        "horizontal": {
+          "type": "boolean"
+        },
+        "pad": {
+          "type": "boolean"
+        },
+        "type": {
+          "const": "list",
+          "type": "string"
+        }
+      },
+      "required": [
+        "elements",
+        "type"
+      ],
+      "type": "object"
+    },
+    "MessageView": {
+      "additionalProperties": false,
+      "properties": {
+        "content": {
+          "$ref": "#/definitions/ViewUnion"
+        },
+        "highlight": {
+          "type": "boolean"
+        },
+        "ownMessage": {
+          "type": "boolean"
+        },
+        "plain": {
+          "type": "boolean"
+        },
+        "role": {
+          "type": "string"
+        },
+        "type": {
+          "const": "message",
+          "type": "string"
+        }
+      },
+      "required": [
+        "content",
+        "type"
+      ],
+      "type": "object"
+    },
+    "SeparatedValuesView": {
+      "additionalProperties": false,
+      "properties": {
+        "header": {
+          "type": "string"
+        },
+        "highlight": {
+          "type": "boolean"
+        },
+        "separator": {
+          "type": "string"
+        },
+        "type": {
+          "const": "separatedValues",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "TextView": {
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "type": "string"
+        },
+        "type": {
+          "const": "text",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "VStackView": {
+      "additionalProperties": false,
+      "properties": {
+        "border": {
+          "type": "boolean"
+        },
+        "collapsible": {
+          "type": "string"
+        },
+        "keys": {
+          "additionalProperties": {
+            "$ref": "#/definitions/ViewUnion"
+          },
+          "type": "object"
+        },
+        "pad": {
+          "type": "boolean"
+        },
+        "type": {
+          "const": "vstack",
+          "type": "string"
+        }
+      },
+      "required": [
+        "keys",
+        "type"
+      ],
+      "type": "object"
+    },
+    "View": {
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/ViewType"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "ViewSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/ViewUnion"
+        },
+        "displayType": {
+          "$ref": "#/definitions/DisplayType"
+        },
+        "label": {
+          "$ref": "#/definitions/ViewUnion"
+        },
+        "output": {
+          "$ref": "#/definitions/ViewUnion"
+        }
+      },
+      "required": [
+        "data",
+        "label",
+        "output"
+      ],
+      "type": "object"
+    },
+    "ViewType": {
+      "enum": [
+        "text",
+        "image",
+        "audio",
+        "code",
+        "markdown",
+        "list",
+        "vstack",
+        "message",
+        "separatedValues"
+      ],
+      "type": "string"
+    },
+    "ViewUnion": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/View"
+        },
+        {
+          "$ref": "#/definitions/TextView"
+        },
+        {
+          "$ref": "#/definitions/ImageView"
+        },
+        {
+          "$ref": "#/definitions/ListView"
+        },
+        {
+          "$ref": "#/definitions/MessageView"
+        },
+        {
+          "$ref": "#/definitions/VStackView"
+        },
+        {
+          "$ref": "#/definitions/SeparatedValuesView"
+        }
+      ]
+    }
+  }
+}

--- a/frontend/src/lib/instance-views/schema.ts
+++ b/frontend/src/lib/instance-views/schema.ts
@@ -1,0 +1,80 @@
+export enum ViewType {
+	// direct data renderers
+	'text' = 'text',
+	'image' = 'image',
+	'audio' = 'audio',
+	'code' = 'code',
+	'markdown' = 'markdown',
+	// data containers
+	'list' = 'list',
+	'vstack' = 'vstack',
+	'message' = 'message',
+	'separatedValues' = 'separatedValues'
+}
+
+export enum DisplayType {
+	'table' = 'table'
+}
+
+export type ViewUnion =
+	| View
+	| TextView
+	| ImageView
+	| ListView
+	| MessageView
+	| VStackView
+	| SeparatedValuesView;
+
+export interface View {
+	type: ViewType;
+}
+
+export interface TextView extends View {
+	type: ViewType.text;
+	label?: string;
+}
+
+export interface ImageView extends View {
+	type: ViewType.image;
+	maxWidth?: 'small' | 'medium' | 'large' | 'full';
+}
+
+export interface ListView extends View {
+	type: ViewType.list;
+	elements: ViewUnion;
+	horizontal?: boolean;
+	collapsible?: string;
+	border?: boolean;
+	pad?: boolean;
+}
+
+export interface MessageView extends View {
+	type: ViewType.message;
+	content: ViewUnion;
+	plain?: boolean;
+	role?: string;
+	ownMessage?: boolean;
+	highlight?: boolean;
+}
+
+export interface VStackView extends View {
+	type: ViewType.vstack;
+	keys: Record<string, ViewUnion>;
+	collapsible?: string;
+	border?: boolean;
+	pad?: boolean;
+}
+
+export interface SeparatedValuesView extends View {
+	type: ViewType.separatedValues;
+	header?: string;
+	separator?: string;
+	highlight?: boolean;
+}
+
+export interface ViewSchema {
+	data: ViewUnion;
+	label: ViewUnion;
+	output: ViewUnion;
+	displayType?: DisplayType;
+}

--- a/frontend/src/routes/playground/+layout.ts
+++ b/frontend/src/routes/playground/+layout.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/frontend/src/routes/playground/+page.svelte
+++ b/frontend/src/routes/playground/+page.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import InstanceView from '$lib/instance-views/InstanceView.svelte';
+	import { json } from '@codemirror/lang-json';
+	import CodeMirror from 'svelte-codemirror-editor';
+
+	import { browser } from '$app/environment';
+	import Error from '$lib/instance-views/Error.svelte';
+	import { samples } from './samples.js';
+	import { setURLParameters, type URLParams } from './util.js';
+
+	let sample: string | undefined;
+
+	const searchParams = browser && $page.url.searchParams;
+	if (searchParams && searchParams.get('params')) {
+		const decodedString = atob(searchParams.get('params') ?? '');
+		const urlParams = JSON.parse(decodedString) as URLParams;
+		sample = urlParams.sample;
+	}
+
+	let spec = sample === undefined ? samples[Object.keys(samples)[0]].spec : samples[sample].spec;
+	let currentData =
+		sample === undefined ? samples[Object.keys(samples)[0]].data : samples[sample].data;
+	let jsonData: Record<string, unknown> | undefined = undefined;
+	let errorMessage: string | undefined = undefined;
+
+	$: setURLParameters(sample);
+
+	$: try {
+		jsonData = JSON.parse(currentData);
+		errorMessage = undefined;
+	} catch (error) {
+		jsonData = undefined;
+		errorMessage = error as string;
+	}
+</script>
+
+<div class="flex h-full w-full flex-col p-4">
+	<h1 class="mb-2 text-2xl font-bold">Zeno View Playground</h1>
+	<div class="flex w-full items-center pb-4">
+		<h2 class="pr-4 text-xl">Examples:</h2>
+		<div class="flex items-center overflow-x-auto">
+			{#each Object.keys(samples) as currentSample}
+				<button
+					class="mr-2 cursor-pointer whitespace-nowrap rounded-full border border-grey-light p-2 hover:bg-grey-lighter {spec ===
+						samples[currentSample].spec && currentData === samples[currentSample].data
+						? 'bg-primary-light'
+						: 'bg-transparent'}"
+					on:click={() => {
+						spec = samples[currentSample].spec;
+						currentData = samples[currentSample].data;
+						sample = currentSample;
+					}}>{currentSample}</button
+				>
+			{/each}
+		</div>
+	</div>
+	<div class="flex h-full w-full">
+		<div class="h-full w-1/3 border-r border-grey-light p-2">
+			<div class="flex flex-col">
+				<h2 class="mb-4 text-xl font-bold">View Specification</h2>
+				<CodeMirror bind:value={spec} lang={json()} />
+			</div>
+		</div>
+		<div class="h-full w-1/3 border-r border-grey-light p-2">
+			<div class="flex flex-col">
+				<h2 class="mb-4 text-xl font-bold">Data Sample</h2>
+				<CodeMirror bind:value={currentData} lang={json()} />
+			</div>
+		</div>
+		<div class="h-full w-1/3 p-2">
+			<div class="flex flex-col">
+				<h2 class="mb-4 text-xl font-bold">Instance View</h2>
+				{#if jsonData === undefined}
+					<Error type="Incorrect Data" message={errorMessage} />
+				{:else}
+					<InstanceView
+						view={spec}
+						entry={jsonData}
+						dataColumn="data"
+						labelColumn="label"
+						modelColumn="output"
+					/>
+				{/if}
+			</div>
+		</div>
+	</div>
+</div>

--- a/frontend/src/routes/playground/samples.ts
+++ b/frontend/src/routes/playground/samples.ts
@@ -1,0 +1,323 @@
+export const samples: Record<string, { spec: string; data: string }> = {
+	'image-classification': {
+		spec: JSON.stringify(
+			{
+				data: { type: 'image' },
+				label: { type: 'text' },
+				output: { type: 'text' }
+			},
+			null,
+			2
+		),
+		data: JSON.stringify(
+			{
+				data: 'https://pandas.pydata.org/docs/_static/pandas.svg',
+				label: 'zeno',
+				output: 'zeno'
+			},
+			null,
+			2
+		)
+	},
+	'text-classification': {
+		spec: JSON.stringify(
+			{
+				data: { type: 'text' },
+				label: { type: 'text' },
+				output: { type: 'text' }
+			},
+			null,
+			2
+		),
+		data: JSON.stringify(
+			{
+				data: 'test',
+				label: 'zeno',
+				output: 'zeno'
+			},
+			null,
+			2
+		)
+	},
+	'space-separated-values': {
+		spec: JSON.stringify(
+			{
+				data: { type: 'separatedValues', header: 'Data', separator: ' ' },
+				label: {
+					type: 'separatedValues',
+					header: 'Label',
+					highlight: true,
+					separator: ' '
+				},
+				output: {
+					type: 'separatedValues',
+					header: 'Output',
+					separator: ' '
+				},
+				displayType: 'table'
+			},
+			null,
+			2
+		),
+		data: JSON.stringify(
+			{
+				data: 'test a b c\ntest a b c',
+				label: 'testfsdfs aasd b c\ntest a b c',
+				output: 'test a b c\ntest aasdfd b c'
+			},
+			null,
+			2
+		)
+	},
+	'audio-transcription': {
+		spec: JSON.stringify(
+			{
+				data: { type: 'audio' },
+				label: { type: 'text' },
+				output: { type: 'text' }
+			},
+			null,
+			2
+		),
+		data: JSON.stringify(
+			{
+				data: 'https://github.com/apple/ml-symphony/raw/main/symphony_lib/static/symphony-audio-sample.mp3',
+				label: 'zeno',
+				output: 'zeno'
+			},
+			null,
+			2
+		)
+	},
+	chatbot: {
+		spec: JSON.stringify(
+			{
+				data: {
+					type: 'list',
+					elements: {
+						type: 'message',
+						content: {
+							type: 'text'
+						}
+					},
+					collapsible: 'top'
+				},
+				label: {
+					type: 'message',
+					plain: true,
+					role: 'assistant',
+					highlight: false,
+					content: {
+						type: 'text'
+					}
+				},
+				output: {
+					type: 'message',
+					plain: true,
+					role: 'assistant',
+					highlight: true,
+					content: {
+						type: 'text'
+					}
+				}
+			},
+			null,
+			2
+		),
+		data: JSON.stringify(
+			{
+				data: [
+					{
+						role: 'assistant',
+						content: 'Hello this is Jane at Rivertown Insurance. How can I help you today?'
+					},
+					{
+						role: 'user',
+						content: 'Hi, this is Joe Last and I would like to pay my auto insurance bill.'
+					},
+					{
+						role: 'assistant',
+						content: 'Hello again, this is Jane at Rivertown Insurance. How can I help you today?'
+					},
+					{
+						role: 'user',
+						content: 'Hi, again, this is Joe Last and I would like to pay my auto insurance bill.'
+					},
+					{
+						role: 'assistant',
+						content: 'Hello finally, this is Jane at Rivertown Insurance. How can I help you today?'
+					},
+					{
+						role: 'user',
+						content: 'Hi, finally this is Joe Last and I would like to pay my auto insurance bill.'
+					}
+				],
+				label:
+					'Okay mister Last. I can help you with payment. #Ah first I will need your account number please.',
+				output:
+					'Hello Joe, thank you for choosing Rivertown Insurance as your insurance provider. I can definitely assist you with that. Do you have your policy number and payment information handy?'
+			},
+			null,
+			2
+		)
+	},
+	'chatbot-markdown': {
+		spec: JSON.stringify(
+			{
+				data: {
+					type: 'list',
+					elements: {
+						type: 'message',
+						content: {
+							type: 'markdown'
+						}
+					},
+					collapsible: 'top'
+				},
+				label: {
+					type: 'message',
+					plain: true,
+					role: 'assistant',
+					highlight: false,
+					content: {
+						type: 'markdown'
+					}
+				},
+				output: {
+					type: 'message',
+					plain: true,
+					role: 'assistant',
+					highlight: true,
+					content: {
+						type: 'markdown'
+					}
+				}
+			},
+			null,
+			2
+		),
+		data: JSON.stringify(
+			{
+				data: [
+					{
+						role: 'assistant',
+						content: 'Hello **this** is Jane at Rivertown Insurance. How can I help you today?'
+					},
+					{
+						role: 'user',
+						content: 'Hi, this is Joe Last and I would like to pay my auto insurance bill.'
+					}
+				],
+				label:
+					'Okay ~mister~ Last. I can help you with payment. #Ah first I will need your account number please.',
+				output:
+					'# test \n Hello Joe, thank you for choosing Rivertown Insurance as your insurance provider. I can definitely assist you with that. Do you have your policy number and payment information handy?'
+			},
+			null,
+			2
+		)
+	},
+	'code-generation': {
+		spec: JSON.stringify(
+			{
+				data: { type: 'code' },
+				label: { type: 'code' },
+				output: { type: 'code' }
+			},
+			null,
+			2
+		),
+		data: JSON.stringify(
+			{
+				data: '# sort list of strings',
+				label: 'sorted_list = sorted(my_list)',
+				output:
+					"my_list = ['apple', 'banana', 'cherry']\nsorted_list = sorted(my_list)\nprint(sorted_list)"
+			},
+			null,
+			2
+		)
+	},
+	rag: {
+		spec: JSON.stringify(
+			{
+				data: { type: 'text' },
+				label: { type: 'text' },
+				output: {
+					type: 'vstack',
+					keys: {
+						answer: { type: 'text' },
+						retrieved: {
+							type: 'list',
+							elements: {
+								type: 'vstack',
+								keys: {
+									score: { type: 'text', label: 'score: ' },
+									reference: { type: 'text', label: 'id: ' },
+									text: { type: 'text', label: 'text: ' }
+								}
+							},
+							collapsible: 'bottom',
+							border: true,
+							pad: true
+						}
+					}
+				}
+			},
+			null,
+			2
+		),
+		data: JSON.stringify(
+			{
+				data: 'what do the 3 dots mean in math',
+				output: {
+					answer: 'they are magic dots',
+					retrieved: [
+						{
+							reference: '11259078_10',
+							text: 'BULLET::::3. Karen Salmansohn as Huffington Post columnist (What Do You Tell Kids When They Ask Why Mean People Are Mean? (And what do you tell yourself too?))',
+							score: 11.97700023651123
+						},
+						{
+							reference: '43266366_5',
+							text: '3. "What Do We Mean To Each Other"',
+							score: 11.40779972076416
+						},
+						{
+							reference: '15587152_6',
+							text: 'BULLET::::2. "Do You Know What I Mean" \u2013 3:45',
+							score: 10.996999740600586
+						},
+						{
+							reference: '28286148_8',
+							text: 'BULLET::::- Side A "Do You Know What I Mean" - 3:20',
+							score: 10.99699878692627
+						},
+						{
+							reference: '50920027_10',
+							text: 'BULLET::::6. "Do You Know What I Mean" - 3:11',
+							score: 10.996997833251953
+						},
+						{
+							reference: '54315209_7',
+							text: 'BULLET::::3. "Do You Know What It Means to Miss New Orleans?" (Louis Alter, Eddie DeLange) \u2013 3:30',
+							score: 10.90369987487793
+						},
+						{
+							reference: '7196002_23',
+							text: 'BULLET::::3. "What Do We Mean to Each Other" (duet with Kevyn Lettau)',
+							score: 10.866600036621094
+						},
+						{
+							reference: '7382309_50',
+							text: 'BULLET::::15. "Do You Know What I Mean" \u2013 Lee Michaels \u2013 3:14',
+							score: 10.7391996383667
+						}
+					]
+				}
+			},
+			null,
+			2
+		)
+	}
+};

--- a/frontend/src/routes/playground/util.ts
+++ b/frontend/src/routes/playground/util.ts
@@ -1,0 +1,13 @@
+import { browser } from '$app/environment';
+
+export type URLParams = {
+	sample: string | undefined;
+};
+
+export function setURLParameters(sample: string | undefined) {
+	if (!browser) return;
+	const params = {
+		sample
+	} as URLParams;
+	window.history.replaceState(history.state, '', `?params=${btoa(JSON.stringify(params))}`);
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,9 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-	content: [
-		'./src/**/*.{html,js,svelte,ts}',
-		'./node_modules/@zeno-ml/zeno-instance-views/**/*.{html,js,svelte,ts}'
-	],
+	content: ['./src/**/*.{html,js,svelte,ts}'],
 	theme: {
 		fontFamily: {
 			header: ['"Hammersmith One"', 'sans-serif']

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "zeno-hub",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "zeno-hub",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
# Description

Instead of having a separate instance-views repo, moves it into zeno-hub and creates a playground endpoint.