### PR TITLE
fix: flaky report edits, remove dnd

### DIFF
--- a/frontend/src/lib/components/report/ElementContainer.svelte
+++ b/frontend/src/lib/components/report/ElementContainer.svelte
@@ -12,7 +12,6 @@
 		mdiCheckBold,
 		mdiChevronDown,
 		mdiChevronUp,
-		mdiDrag,
 		mdiPencilOutline,
 		mdiTrashCanOutline
 	} from '@mdi/js';
@@ -27,7 +26,6 @@
 	export let selectedProjects: string[];
 	export let editId: number;
 	export let showConfirmDelete: number;
-	export let dragEnabled: boolean;
 	export let addElement: (elementIndex: number) => void;
 	export let swapElementPositions: (elementId: number | null | undefined, position: number) => void;
 
@@ -54,18 +52,13 @@
 		class="relative border-2
 			{editId === element.id ? 'border-primary-mid' : 'border-white'}
 			{report.editor ? 'group/edit rounded p-4 hover:border-primary-mid' : 'py-2'}
-			{dragEnabled ? 'border-2 border-primary-mid' : ''} transition"
+			transition"
 	>
 		<button
 			class="absolute -top-4 right-14 hidden rounded-md bg-primary-light p-1 transition hover:bg-primary-mid group-hover/edit:block"
 			on:click={() => (showConfirmDelete = element.id ?? -1)}
 		>
-			<Icon
-				style="outline:none; width: 20px; height: 20px"
-				tag="svg"
-				viewBox="0 0 24 24"
-				on:mousedown={() => (dragEnabled = true)}
-			>
+			<Icon style="outline:none; width: 20px; height: 20px" tag="svg" viewBox="0 0 24 24">
 				<path class="fill-primary" d={mdiTrashCanOutline} />
 			</Icon>
 		</button>
@@ -76,29 +69,12 @@
 					? (editId = -1)
 					: (editId = element.id)}
 		>
-			<Icon
-				style="outline:none; width: 20px; height: 20px"
-				tag="svg"
-				viewBox="0 0 24 24"
-				on:mousedown={() => (dragEnabled = true)}
-			>
+			<Icon style="outline:none; width: 20px; height: 20px" tag="svg" viewBox="0 0 24 24">
 				<path class="fill-primary" d={editId === element.id ? mdiCheckBold : mdiPencilOutline} />
 			</Icon>
 		</button>
-		<div
-			class="absolute -left-3 -top-1 mr-2 hidden cursor-move rounded-md bg-primary-light hover:bg-primary-mid group-hover/edit:flex"
-		>
-			<Icon
-				style="outline:none; width: 24px; height: 24px"
-				tag="svg"
-				viewBox="0 0 24 24"
-				on:mousedown={() => (dragEnabled = true)}
-			>
-				<path class="fill-primary" d={mdiDrag} />
-			</Icon>
-		</div>
 		<button
-			class="absolute -left-3 top-7 mr-2 hidden rounded-md bg-primary-light hover:bg-primary-mid group-hover/edit:flex"
+			class="absolute -left-3 top-1 mr-2 hidden rounded-md bg-primary-light hover:bg-primary-mid group-hover/edit:flex"
 			on:click={() => swapElementPositions(element.id, element.position - 1)}
 		>
 			<Icon style="outline:none; width: 24px; height: 24px" tag="svg" viewBox="0 0 24 24">
@@ -106,7 +82,7 @@
 			</Icon>
 		</button>
 		<button
-			class="absolute -left-3 top-14 mr-2 hidden rounded-md bg-primary-light hover:bg-primary-mid group-hover/edit:flex"
+			class="absolute -left-3 top-8 mr-2 hidden rounded-md bg-primary-light hover:bg-primary-mid group-hover/edit:flex"
 			on:click={() => swapElementPositions(element.id, element.position + 1)}
 		>
 			<Icon style="outline:none; width: 24px; height: 24px" tag="svg" viewBox="0 0 24 24">

--- a/frontend/src/lib/components/report/ElementEdit.svelte
+++ b/frontend/src/lib/components/report/ElementEdit.svelte
@@ -31,10 +31,10 @@
 
 	// only add ReportElementTypes if they have at least one option.
 	$: reportElementOptions = [
+		ReportElementType.TEXT,
 		...(chartOptions.length > 0 ? [ReportElementType.CHART] : []),
 		...(sliceOptions.length > 0 ? [ReportElementType.SLICE] : []),
-		...(tagOptions.length > 0 ? [ReportElementType.TAG] : []),
-		ReportElementType.TEXT
+		...(tagOptions.length > 0 ? [ReportElementType.TAG] : [])
 	];
 
 	async function updateType(e: CustomEvent) {

--- a/frontend/src/routes/(app)/report/[id]/[name]/+page.svelte
+++ b/frontend/src/routes/(app)/report/[id]/[name]/+page.svelte
@@ -30,7 +30,7 @@
 		zenoClient
 			.addReportElement(data.report.id, {
 				type: ReportElementType.TEXT,
-				data: 'new element I',
+				data: 'new element',
 				position: elementIndex
 			})
 			.then((res) => {
@@ -38,7 +38,7 @@
 				elements.push({
 					id: res,
 					type: ReportElementType.TEXT,
-					data: 'new element I',
+					data: 'new element',
 					position: elementIndex
 				});
 				elements = elements.sort((a, b) => a.position - b.position);

--- a/frontend/src/routes/(app)/report/[id]/[name]/+page.svelte
+++ b/frontend/src/routes/(app)/report/[id]/[name]/+page.svelte
@@ -6,10 +6,9 @@
 	import AddElementButton from '$lib/components/report/AddElementButton.svelte';
 	import ElementContainer from '$lib/components/report/ElementContainer.svelte';
 	import { svelecteRendererName } from '$lib/util/util.js';
-	import { ReportElementType, ZenoService, type Project, type ReportElement } from '$lib/zenoapi';
+	import { ReportElementType, ZenoService, type Project } from '$lib/zenoapi';
 	import Svelecte from 'svelecte';
 	import { getContext } from 'svelte';
-	import { dndzone } from 'svelte-dnd-action';
 
 	export let data;
 
@@ -18,7 +17,6 @@
 	let selectedProjects = data.report.linkedProjects ?? [];
 	let editId = -1;
 	let showConfirmDelete = -1;
-	let dragEnabled = false;
 
 	const zenoClient = getContext('zenoClient') as ZenoService;
 
@@ -32,7 +30,7 @@
 		zenoClient
 			.addReportElement(data.report.id, {
 				type: ReportElementType.TEXT,
-				data: 'new element',
+				data: 'new element I',
 				position: elementIndex
 			})
 			.then((res) => {
@@ -40,7 +38,7 @@
 				elements.push({
 					id: res,
 					type: ReportElementType.TEXT,
-					data: 'new element',
+					data: 'new element I',
 					position: elementIndex
 				});
 				elements = elements.sort((a, b) => a.position - b.position);
@@ -51,19 +49,6 @@
 	function updateReportProjects(e: CustomEvent) {
 		const projectUuids = e.detail.map((p: Project) => p.uuid);
 		zenoClient.updateReportProjects(data.report.id, projectUuids);
-	}
-
-	function handleDropped(e: CustomEvent) {
-		e.detail.items.forEach((item: ReportElement, index: number) => {
-			item.position = index;
-			zenoClient.updateReportElement(data.report.id, { ...item, position: index });
-		});
-		elements = e.detail.items;
-		dragEnabled = false;
-	}
-
-	function handleMoved(e: CustomEvent) {
-		elements = e.detail.items;
 	}
 
 	function swapElementPositions(elementId: number | null | undefined, position: number) {
@@ -168,22 +153,11 @@
 					alwaysShow={elements.length === 0 ? true : false}
 				/>
 			{/if}
-			<div
-				class="mt-2 flex flex-col"
-				use:dndzone={{
-					items: elements,
-					dragDisabled: !dragEnabled,
-					dropTargetStyle: {},
-					flipDurationMs: 100
-				}}
-				on:consider={handleMoved}
-				on:finalize={handleDropped}
-			>
+			<div class="mt-2 flex flex-col">
 				{#each elements as element (element.id)}
 					<ElementContainer
-						{element}
+						bind:element
 						bind:editId
-						bind:dragEnabled
 						bind:showConfirmDelete
 						{swapElementPositions}
 						{addElement}


### PR DESCRIPTION
# Description
Drag to move elements was buggy and slow, not even useful since we didn't auto scroll. Removed it and fixed binding to keep frontend and backend synced.

Fix ZEN-351