### PR TITLE
fix: prevent crash for none values as buckets

### DIFF
--- a/backend/zeno_backend/classes/metadata.py
+++ b/backend/zeno_backend/classes/metadata.py
@@ -16,7 +16,7 @@ class HistogramBucket(CamelModel):
         metric (float | None): the metric value of the bucket.
     """
 
-    bucket: float | bool | int | str
+    bucket: float | bool | int | str | None
     bucket_end: float | bool | int | str | None = None
     size: int | None = None
     filtered_size: int | None = None


### PR DESCRIPTION
# Description

The histogram would crash if there was a none value as bucket (which could happen if you provide either string or none as data in a col).
