### PR TITLE
fix: prevent overlap of container when showing options

### DIFF
--- a/frontend/src/lib/components/home/EntryOptions.svelte
+++ b/frontend/src/lib/components/home/EntryOptions.svelte
@@ -14,7 +14,7 @@
 	const exploreTab = $page.route.id === '/(app)/home';
 </script>
 
-<div class="absolute right-0 top-0 z-30 mt-9 hover:bg-grey-lighter">
+<div class="absolute left-0 top-0 z-30 mt-9 hover:bg-grey-lighter">
 	<Paper style="padding: 3px 0px;" elevation={7}>
 		<Content>
 			{#if project}

--- a/frontend/src/lib/components/home/HomeCard.svelte
+++ b/frontend/src/lib/components/home/HomeCard.svelte
@@ -78,8 +78,14 @@
 		)}
 	on:mouseover={() => (hovering = true)}
 	on:focus={() => (hovering = true)}
-	on:mouseleave={() => (hovering = false)}
-	on:blur={() => (hovering = false)}
+	on:mouseleave={() => {
+		hovering = false;
+		showOptions = false;
+	}}
+	on:blur={() => {
+		hovering = false;
+		showOptions = false;
+	}}
 	class="flex h-full w-full flex-col rounded-md border border-solid border-grey-light bg-white hover:shadow-sm"
 >
 	<div


### PR DESCRIPTION
# Description

Old:

<img width="332" alt="image" src="https://github.com/zeno-ml/zeno-hub/assets/5690524/c785c2ba-9384-47b9-8642-1be7a7d3311a">

New:

<img width="336" alt="image" src="https://github.com/zeno-ml/zeno-hub/assets/5690524/290adbdc-e531-4347-835a-4fb0d84167e0">
