### PR TITLE
fix: set tagIds correctly when loading a project with a tag selected

### DIFF
--- a/frontend/src/routes/(app)/project/[uuid]/[name]/+layout.svelte
+++ b/frontend/src/routes/(app)/project/[uuid]/[name]/+layout.svelte
@@ -19,6 +19,7 @@
 		selectionIds,
 		selections,
 		slices,
+		tagIds,
 		tags
 	} from '$lib/stores.js';
 	import { setURLParameters } from '$lib/util/util.js';
@@ -45,6 +46,14 @@
 		selectionIds.set([]);
 		filterSelection.set(false);
 		editTag.set(undefined);
+		// Set tagIds according to the selection we get from URL params
+		tagIds.set(
+			data.selections.tags.flatMap((selectionTag) => {
+				const tag = data.tags.find((tag) => tag.id === selectionTag);
+				if (tag === undefined) return [];
+				return tag.dataIds;
+			})
+		);
 
 		model.subscribe((mod) => {
 			if ($comparisonModel && $comparisonModel === mod) {


### PR DESCRIPTION
# Description

Previously, we did not correctly load selected tags.