### PR TITLE
fix: make instances always reflect current model

### DIFF
--- a/frontend/src/lib/components/instances/ComparisonView.svelte
+++ b/frontend/src/lib/components/instances/ComparisonView.svelte
@@ -61,10 +61,10 @@
 
 	$: modelAColumn = $columns.find(
 		(col) => col.columnType === ZenoColumnType.OUTPUT && col.model === $model
-	);
+	)?.id;
 	$: modelBColumn = $columns.find(
 		(col) => col.columnType === ZenoColumnType.OUTPUT && col.model === $comparisonModel
-	);
+	)?.id;
 
 	// when state changes update current table view
 	$: {
@@ -81,7 +81,6 @@
 		updateTable(true);
 	}
 	$: {
-		$model;
 		$selectionIds;
 		$filterSelection;
 		updateTable();
@@ -268,7 +267,7 @@
 			</th>
 		</thead>
 		<tbody>
-			{#each table as tableContent (tableContent[idColumn])}
+			{#each table as tableContent (`${tableContent[idColumn]}_${modelAColumn}_${modelBColumn}`)}
 				<tr>
 					<td class="p-3 align-baseline">
 						<p class="mb-2">
@@ -280,7 +279,7 @@
 								view={$project.view}
 								{dataColumn}
 								{labelColumn}
-								modelColumn={modelAColumn?.id}
+								modelColumn={modelAColumn}
 								entry={tableContent}
 								selectable
 							/>
@@ -296,7 +295,7 @@
 								view={$project.view}
 								{dataColumn}
 								{labelColumn}
-								modelColumn={modelBColumn?.id}
+								modelColumn={modelBColumn}
 								entry={tableContent}
 								selectable
 							/>

--- a/frontend/src/lib/components/instances/ListView.svelte
+++ b/frontend/src/lib/components/instances/ListView.svelte
@@ -59,7 +59,6 @@
 		updateTable(true);
 	}
 	$: {
-		$model;
 		$selectionIds;
 		$filterSelection;
 		updateTable();
@@ -67,7 +66,7 @@
 
 	$: modelColumn = $columns.find(
 		(col) => col.columnType === ZenoColumnType.OUTPUT && col.model === $model
-	);
+	)?.id;
 
 	// reset page on selection change
 	selectionPredicates.subscribe(() => {
@@ -113,13 +112,13 @@
 	style="grid-template-columns: repeat(auto-fill, minmax(400px, 1fr)); grid-auto-rows: min-content;"
 	bind:this={listContainer}
 >
-	{#each table as inst (inst[idColumn])}
+	{#each table as inst (`${inst[idColumn]}_${modelColumn}`)}
 		<div class="mr-2 mt-2">
 			<InstanceView
 				view={$project.view}
 				{dataColumn}
 				{labelColumn}
-				modelColumn={modelColumn?.id}
+				{modelColumn}
 				entry={inst}
 				selectable
 			/>

--- a/frontend/src/lib/components/instances/TableView.svelte
+++ b/frontend/src/lib/components/instances/TableView.svelte
@@ -69,14 +69,13 @@
 		updateTable(true);
 	}
 	$: {
-		$model;
 		$selectionIds;
 		$filterSelection;
 		updateTable();
 	}
 	$: modelColumn = $columns.find(
 		(col) => col.columnType === ZenoColumnType.OUTPUT && col.model === $model
-	);
+	)?.id;
 
 	// reset page on selection change
 	selectionPredicates.subscribe(() => {
@@ -166,7 +165,7 @@
 			</tr>
 		</thead>
 		<tbody>
-			{#each table as tableContent (tableContent[idColumn])}
+			{#each table as tableContent (`${tableContent[idColumn]}_${modelColumn}`)}
 				<tr class="border-b border-grey-lighter">
 					<td class="border border-grey-lighter p-3 align-top">
 						{tableContent[idColumn]}
@@ -181,7 +180,7 @@
 										view={$project.view}
 										{dataColumn}
 										{labelColumn}
-										modelColumn={modelColumn?.id}
+										{modelColumn}
 										entry={tableContent}
 										selectable
 									/>


### PR DESCRIPTION
Instances sometimes did not update when changing the model. This has been fixed by adding an identifier for the model column to the list. Additionally, we don't need to reload the data when changing the model. The table stays the same.