### PR TITLE
feat: show metric for binary metadata

### DIFF
--- a/frontend/src/lib/components/metadata/cells/metadata-cells/BinaryMetadataCell.svelte
+++ b/frontend/src/lib/components/metadata/cells/metadata-cells/BinaryMetadataCell.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { metricRangeColorScale } from '$lib/stores';
+	import { tooltip } from '$lib/util/tooltip';
 	import {
 		Join,
 		Operation,
@@ -53,6 +54,7 @@
 				style="background-color: {$metricRangeColorScale(histogram[0].metric ?? 0)}"
 				on:click={() => setSelection(true)}
 				on:keydown={() => setSelection(true)}
+				use:tooltip={{ text: `Metric: ${histogram[0].metric?.toFixed(2)}` }}
 			>
 				<Label>True</Label>
 			</button>
@@ -67,6 +69,7 @@
 				style="background-color: {$metricRangeColorScale(histogram[1].metric ?? 0)}"
 				on:click={() => setSelection(false)}
 				on:keydown={() => setSelection(false)}
+				use:tooltip={{ text: `Metric: ${histogram[1].metric?.toFixed(2)}` }}
 			>
 				<Label>False</Label>
 			</button>


### PR DESCRIPTION
Does not look the same as the vega tooltip but probably fine for noe?

fix ZEN-374