### PR TITLE
fix: throw correct error so frontend redirects

### DIFF
--- a/backend/zeno_backend/database/select.py
+++ b/backend/zeno_backend/database/select.py
@@ -885,7 +885,7 @@ def project_from_uuid(project_uuid: str) -> Project:
         )
         if len(project_result) == 0:
             raise HTTPException(
-                status.HTTP_500_INTERNAL_SERVER_ERROR,
+                status.HTTP_404_NOT_FOUND,
                 "ERROR: Project could not be found.",
             )
         project_result = project_result[0]


### PR DESCRIPTION
# Description

When calling a project by owner/name we threw the wrong error and hence did not redirect correctly.
