### PR TITLE
fix: allow duplicate slice names

### DIFF
--- a/backend/zeno_backend/database/insert.py
+++ b/backend/zeno_backend/database/insert.py
@@ -640,25 +640,18 @@ async def all_slices_for_column(
                     folder_id=None if folder_id is None else folder_id[0],
                 )
                 await cur.execute(
-                    sql.SQL(
-                        "SELECT id FROM slices WHERE name={} AND project_uuid={};"
-                    ).format(slice.slice_name, project)
+                    "INSERT INTO slices (name, filter, project_uuid, folder_id) "
+                    "VALUES (%s,%s,%s,%s) RETURNING id;",
+                    [
+                        slice.slice_name,
+                        json.dumps(slice.filter_predicates, cls=PredicatesEncoder),
+                        project,
+                        slice.folder_id,
+                    ],
                 )
-                exists = await cur.fetchall()
-                if len(exists) == 0:
-                    await cur.execute(
-                        "INSERT INTO slices (name, filter, project_uuid, folder_id) "
-                        "VALUES (%s,%s,%s,%s) RETURNING id;",
-                        [
-                            slice.slice_name,
-                            json.dumps(slice.filter_predicates, cls=PredicatesEncoder),
-                            project,
-                            slice.folder_id,
-                        ],
-                    )
-                    id = await cur.fetchone()
-                    if id is not None:
-                        ids.append(id[0])
+                id = await cur.fetchone()
+                if id is not None:
+                    ids.append(id[0])
     return ids
 
 

--- a/frontend/src/lib/components/metadata/Slices.svelte
+++ b/frontend/src/lib/components/metadata/Slices.svelte
@@ -61,7 +61,7 @@
 	{#each $folders as folder}
 		<FolderCell {folder} />
 	{/each}
-	{#each $slices.filter((s) => s.folderId === null || s.folderId === undefined) as s (s.sliceName)}
+	{#each $slices.filter((s) => s.folderId === null || s.folderId === undefined) as s (s.id)}
 		<SliceCell compare={$page.url.href.includes('compare')} slice={s} />
 	{/each}
 </div>

--- a/frontend/src/lib/components/popups/SlicePopup.svelte
+++ b/frontend/src/lib/components/popups/SlicePopup.svelte
@@ -30,7 +30,6 @@
 	let error: string | undefined = undefined;
 
 	// Track original settings when editing.
-	let originalName = '';
 	let originalPredicates;
 
 	$: isValidPredicates = checkValidPredicates(predicateGroup.predicates);
@@ -81,7 +80,6 @@
 			sliceName = sliceToEdit.sliceName;
 			predicateGroup = sliceToEdit.filterPredicates;
 			folderId = sliceToEdit.folderId === null ? undefined : sliceToEdit.folderId;
-			originalName = sliceName;
 			// deep copy of predicate group to avoid sharing nested objects
 			originalPredicates = JSON.parse(JSON.stringify(predicateGroup));
 

--- a/frontend/src/lib/components/popups/SlicePopup.svelte
+++ b/frontend/src/lib/components/popups/SlicePopup.svelte
@@ -220,7 +220,6 @@
 				<Button
 					variant="outlined"
 					on:click={createAllSlices}
-					disabled={$slices.some((slice) => slice.sliceName === sliceName)}
 				>
 					{'Create Slices for all Values'}
 				</Button>
@@ -228,11 +227,7 @@
 				<Button
 					variant="outlined"
 					on:click={saveSlice}
-					disabled={(!sliceToEdit && $slices.some((slice) => slice.sliceName === sliceName)) ||
-						(sliceToEdit &&
-							originalName !== sliceName &&
-							$slices.some((slice) => slice.sliceName === sliceName)) ||
-						!isValidPredicates}
+					disabled={!isValidPredicates}
 				>
 					{sliceToEdit ? 'Update Slice' : 'Create Slice'}
 				</Button>
@@ -240,9 +235,6 @@
 			<Button style="margin-right: 10px" variant="outlined" on:click={() => dispatch('close')}>
 				cancel
 			</Button>
-			{#if (!sliceToEdit && $slices.some((slice) => slice.sliceName === sliceName)) || (sliceToEdit && originalName !== sliceName && $slices.some((slice) => slice.sliceName === sliceName))}
-				<p style:margin-right="10px" style:color="red">slice already exists</p>
-			{/if}
 		</div>
 		{#if error}
 			<div class="flex flex-row-reverse items-center">

--- a/frontend/src/lib/components/popups/SlicePopup.svelte
+++ b/frontend/src/lib/components/popups/SlicePopup.svelte
@@ -217,18 +217,11 @@
 		<FilterGroupEntry index={-1} deletePredicate={() => deletePredicate(-1)} bind:predicateGroup />
 		<div class="flex flex-row-reverse items-center">
 			{#if checkNominalSinglePredicateNoEntry(predicateGroup)}
-				<Button
-					variant="outlined"
-					on:click={createAllSlices}
-				>
+				<Button variant="outlined" on:click={createAllSlices}>
 					{'Create Slices for all Values'}
 				</Button>
 			{:else}
-				<Button
-					variant="outlined"
-					on:click={saveSlice}
-					disabled={!isValidPredicates}
-				>
+				<Button variant="outlined" on:click={saveSlice} disabled={!isValidPredicates}>
 					{sliceToEdit ? 'Update Slice' : 'Create Slice'}
 				</Button>
 			{/if}


### PR DESCRIPTION
# Description

Allow duplicate slice names, mainly so we can easily "Create slices for all values" without worrying about existing slice names. This was decided during a discussion on [ZEN-282](https://linear.app/zenoml/issue/ZEN-282/create-chart-from-metadata-histogram). 

(Note: we probably need a way to disambiguate slices with the same name in the chart editor … maybe by including the folder name as well)

# References

fix ZEN-399

