### PR TITLE
feat: create common style for select eleemnts

### DIFF
--- a/frontend/src/lib/components/home/HomeSearchBar.svelte
+++ b/frontend/src/lib/components/home/HomeSearchBar.svelte
@@ -5,6 +5,7 @@
 	import { Input } from '@smui/textfield';
 	import { createEventDispatcher } from 'svelte';
 	import Spinner from '../general/Spinner.svelte';
+	import Select from '../ui/Select.svelte';
 
 	export let searchText: string;
 	export let typeFilter: EntryTypeFilter;
@@ -52,18 +53,26 @@
 		{/if}
 		<div class="ml-4 flex items-center">
 			<p class="mr-1 text-grey-dark">Filter:</p>
-			<select class="h-full px-2" bind:value={typeFilter} on:change={() => dispatch('change')}>
-				<option value={EntryTypeFilter.ALL}>Projects & Reports</option>
-				<option value={EntryTypeFilter.PROJECT}>Projects</option>
-				<option value={EntryTypeFilter.REPORT}>Reports</option>
-			</select>
+			<Select
+				bind:value={typeFilter}
+				on:change={() => dispatch('change')}
+				options={[
+					{ value: EntryTypeFilter.ALL, label: 'Projects & Reports' },
+					{ value: EntryTypeFilter.PROJECT, label: 'Projects' },
+					{ value: EntryTypeFilter.REPORT, label: 'Reports' }
+				]}
+			/>
 		</div>
 		<div class="ml-6 flex items-center">
 			<p class="mr-1 text-grey-dark">Sort:</p>
-			<select class="h-full px-2" bind:value={sort} on:change={() => dispatch('change')}>
-				<option value={EntrySort.RECENT}>Recent</option>
-				<option value={EntrySort.POPULAR}>Popular</option>
-			</select>
+			<Select
+				bind:value={sort}
+				on:change={() => dispatch('change')}
+				options={[
+					{ value: EntrySort.RECENT, label: 'Recent' },
+					{ value: EntrySort.POPULAR, label: 'Popular' }
+				]}
+			/>
 		</div>
 	</div>
 </div>

--- a/frontend/src/lib/components/instances/ComparisonView.svelte
+++ b/frontend/src/lib/components/instances/ComparisonView.svelte
@@ -22,6 +22,7 @@
 	import { Pagination } from '@smui/data-table';
 	import IconButton from '@smui/icon-button';
 	import { getContext } from 'svelte';
+	import Select from '../ui/Select.svelte';
 
 	export let modelAResult: Promise<GroupMetric[] | undefined>;
 	export let modelBResult: Promise<GroupMetric[] | undefined>;
@@ -325,11 +326,12 @@
 <Pagination slot="paginate" class="pagination">
 	<svelte:fragment slot="rowsPerPage">
 		<Label>Rows Per Page</Label>
-		<select class="ml-2" bind:value={$rowsPerPage}>
-			{#each sampleOptions as option}
-				<option value={option}>{option}</option>
-			{/each}
-		</select>
+		<Select
+			bind:value={$rowsPerPage}
+			options={sampleOptions.map((option) => {
+				return { value: option, label: option };
+			})}
+		/>
 	</svelte:fragment>
 	<svelte:fragment slot="total">
 		{start + 1} -

--- a/frontend/src/lib/components/instances/ListView.svelte
+++ b/frontend/src/lib/components/instances/ListView.svelte
@@ -20,6 +20,7 @@
 	import { Pagination } from '@smui/data-table';
 	import IconButton from '@smui/icon-button';
 	import { getContext } from 'svelte';
+	import Select from '../ui/Select.svelte';
 
 	export let numberOfInstances = 0;
 
@@ -139,11 +140,12 @@
 <Pagination slot="paginate" class="pagination border-none">
 	<svelte:fragment slot="rowsPerPage">
 		<Label>Instances Per Page</Label>
-		<select class="ml-2" bind:value={$rowsPerPage}>
-			{#each sampleOptions as option}
-				<option value={option}>{option}</option>
-			{/each}
-		</select>
+		<Select
+			bind:value={$rowsPerPage}
+			options={sampleOptions.map((option) => {
+				return { value: option, label: option };
+			})}
+		/>
 	</svelte:fragment>
 	<svelte:fragment slot="total">
 		{(start + 1).toLocaleString()} -

--- a/frontend/src/lib/components/instances/TableView.svelte
+++ b/frontend/src/lib/components/instances/TableView.svelte
@@ -21,6 +21,7 @@
 	import { Pagination } from '@smui/data-table';
 	import IconButton from '@smui/icon-button';
 	import { getContext } from 'svelte';
+	import Select from '../ui/Select.svelte';
 
 	export let numberOfInstances = 0;
 
@@ -215,11 +216,12 @@
 <Pagination slot="paginate" class="pagination">
 	<svelte:fragment slot="rowsPerPage">
 		<Label>Rows Per Page</Label>
-		<select class="ml-2" bind:value={$rowsPerPage}>
-			{#each sampleOptions as option}
-				<option value={option}>{option}</option>
-			{/each}
-		</select>
+		<Select
+			bind:value={$rowsPerPage}
+			options={sampleOptions.map((option) => {
+				return { value: option, label: option };
+			})}
+		/>
 	</svelte:fragment>
 	<svelte:fragment slot="total">
 		{start + 1} -

--- a/frontend/src/lib/components/metadata/MetadataHeader.svelte
+++ b/frontend/src/lib/components/metadata/MetadataHeader.svelte
@@ -9,6 +9,7 @@
 		model,
 		models
 	} from '$lib/stores';
+	import Select from '../ui/Select.svelte';
 
 	let comparisonColumnOptions = $columns.filter((c) => c.model === $model);
 	if (!$comparisonColumn) {
@@ -26,42 +27,34 @@
 			<span class="my-1 w-fit text-grey-dark">
 				{$page.url.href.includes('compare') ? 'System A' : 'System'}
 			</span>
-			<select
-				class="h-9 w-full rounded border border-grey-light text-sm text-grey"
+			<Select
 				bind:value={$model}
-			>
-				{#each sortedModels as mod}
-					<option class="p-1" value={mod}>{mod}</option>
-				{/each}
-			</select>
+				options={sortedModels.map((model) => {
+					return { value: model, label: model };
+				})}
+			/>
 		</div>
 	{/if}
 	{#if !$page.url.href.includes('compare') && $metrics.length > 0 && $metric !== undefined}
 		<div class="flex w-1/2 flex-col">
 			<span class="my-1 text-grey-dark">Metric</span>
-			<select
-				class="h-9 w-full rounded border border-grey-light text-sm text-grey"
-				name="metric-select"
-				required
+			<Select
 				bind:value={$metric}
-			>
-				{#each sortedMetrics as met}
-					<option value={met}>{met.name}</option>
-				{/each}
-			</select>
+				options={sortedMetrics.map((metric) => {
+					return { value: metric, label: metric.name };
+				})}
+			/>
 		</div>
 	{/if}
 	{#if $page.url.href.includes('compare')}
 		<div class="flex w-1/2 flex-col">
 			<span class="my-1 text-grey-dark">System B</span>
-			<select
-				class="h-9 w-full rounded border border-grey-light text-sm text-grey"
+			<Select
 				bind:value={$comparisonModel}
-			>
-				{#each excludeModels as mod}
-					<option value={mod}>{mod}</option>
-				{/each}
-			</select>
+				options={excludeModels.map((model) => {
+					return { value: model, label: model };
+				})}
+			/>
 		</div>
 	{/if}
 </div>
@@ -69,27 +62,23 @@
 {#if $page.url.href.includes('compare') && comparisonColumnOptions.length > 0}
 	<div class="my-3">
 		<h4 class="mb-1">Comparison Feature</h4>
-		<select
-			class="h-9 w-full rounded border border-grey-light text-sm text-grey"
+		<Select
 			bind:value={$comparisonColumn}
-		>
-			{#each comparisonColumnOptions as col (col.id)}
-				<option value={col}>{col.name}</option>
-			{/each}
-		</select>
+			options={comparisonColumnOptions.map((col) => {
+				return { value: col, label: col.name };
+			})}
+		/>
 	</div>
 {/if}
 
 {#if $page.url.href.includes('compare') && $metric !== undefined && $metrics.length > 0}
 	<div class="my-3 flex w-full flex-col">
 		<span class="my-1 text-grey-dark">Metric</span>
-		<select
-			class="h-9 w-full rounded border border-grey-light text-sm text-grey"
+		<Select
 			bind:value={$metric}
-		>
-			{#each sortedMetrics as met}
-				<option value={met}>{met.name}</option>
-			{/each}
-		</select>
+			options={sortedMetrics.map((metric) => {
+				return { value: metric, label: metric.name };
+			})}
+		/>
 	</div>
 {/if}

--- a/frontend/src/lib/components/popups/UpdateTagPopup.svelte
+++ b/frontend/src/lib/components/popups/UpdateTagPopup.svelte
@@ -4,6 +4,7 @@
 	import Button from '@smui/button';
 	import { Content } from '@smui/paper';
 	import { createEventDispatcher, getContext } from 'svelte';
+	import Select from '../ui/Select.svelte';
 	import Popup from './Popup.svelte';
 
 	const dispatch = createEventDispatcher();
@@ -47,11 +48,12 @@
 
 <Popup on:close>
 	<Content style="display: flex; align-items: center;">
-		<select class="x-2 h-full" bind:value={selectedTag}>
-			{#each $tags as tag}
-				<option value={tag}>{tag.tagName}</option>
-			{/each}
-		</select>
+		<Select
+			bind:value={selectedTag}
+			options={$tags.map((tag) => {
+				return { value: tag, label: tag.tagName };
+			})}
+		/>
 		<Button style="margin-left: 10px;" variant="outlined" on:click={() => dispatch('close')}
 			>Cancel</Button
 		>

--- a/frontend/src/lib/components/ui/Select.svelte
+++ b/frontend/src/lib/components/ui/Select.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+
+	export let value: unknown;
+	export let options: { value: unknown; label: string | number }[];
+
+	let dispatch = createEventDispatcher();
+</script>
+
+<div class="relative">
+	<select
+		class="w-full appearance-none rounded border border-grey-light px-2 py-1.5 pe-8 outline-none transition ease-in-out"
+		bind:value
+		on:change={() => dispatch('change')}
+	>
+		{#each options as option}
+			<option value={option.value}>{option.label}</option>
+		{/each}
+	</select>
+	<span class="pointer-events-none absolute inset-y-0 right-0 ml-3 flex items-center pr-2">
+		<svg class="text-gray-400 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+			<path
+				fill-rule="evenodd"
+				d="M10 3a.75.75 0 01.55.24l3.25 3.5a.75.75 0 11-1.1 1.02L10 4.852 7.3 7.76a.75.75 0 01-1.1-1.02l3.25-3.5A.75.75 0 0110 3zm-3.76 9.2a.75.75 0 011.06.04l2.7 2.908 2.7-2.908a.75.75 0 111.1 1.02l-3.25 3.5a.75.75 0 01-1.1 0l-3.25-3.5a.75.75 0 01.04-1.06z"
+				clip-rule="evenodd"
+			/>
+		</svg>
+	</span>
+</div>


### PR DESCRIPTION
# Description

We have been using the browser select element before.

Safari:
<img width="326" alt="image" src="https://github.com/zeno-ml/zeno-hub/assets/5690524/364aa789-a24f-44bd-942b-fae5c11cd733">

Chrome:
<img width="375" alt="image" src="https://github.com/zeno-ml/zeno-hub/assets/5690524/58abdb6b-3f9e-4e5c-94d9-a74d69f0adbb">

This adds a unified select component with a cross-browser UI:
<img width="377" alt="image" src="https://github.com/zeno-ml/zeno-hub/assets/5690524/d43a664a-4dcc-4e6b-ba01-61d088bd2db1">
