### PR TITLE
fix: make table full height even if few small elemnts

### DIFF
--- a/frontend/src/lib/components/instances/TableView.svelte
+++ b/frontend/src/lib/components/instances/TableView.svelte
@@ -127,7 +127,7 @@
 	}
 </script>
 
-<div class="w-full overflow-auto" bind:this={tableContainer}>
+<div class="h-full w-full overflow-auto" bind:this={tableContainer}>
 	<table>
 		<thead class="sticky top-0 z-10 cursor-pointer bg-background text-left">
 			<tr class="box-border border-b border-t border-grey-lighter bg-background">


### PR DESCRIPTION
# Description

Previously, it could happen that the bar at the Bottom of the table was floating mid screen. This has been fixed.