### PR TITLE
feat: add !~ postgres operation for filter predicates

### DIFF
--- a/backend/zeno_backend/classes/filter.py
+++ b/backend/zeno_backend/classes/filter.py
@@ -21,6 +21,7 @@ class Operation(str, Enum):
         LIKE: like.
         ILIKE: ilike.
         REGEX: regex.
+        NOT_REGEX: not matching regex.
     """
 
     EQUAL = "EQUAL"
@@ -32,6 +33,7 @@ class Operation(str, Enum):
     LIKE = "LIKE"
     ILIKE = "ILIKE"
     REGEX = "REGEX"
+    NOT_REGEX = "NOT_REGEX"
 
     def literal(self) -> LiteralString:
         """Obtain a string representation to be used in a SQL filter.
@@ -55,6 +57,8 @@ class Operation(str, Enum):
             return "ILIKE"
         if self == Operation.REGEX:
             return "~"
+        if self == Operation.NOT_REGEX:
+            return "!~"
         return "LIKE"
 
 

--- a/frontend/src/lib/components/popups/FilterEntry.svelte
+++ b/frontend/src/lib/components/popups/FilterEntry.svelte
@@ -75,7 +75,7 @@
 			}}
 		/>
 	</div>
-	<div class="mr-2.5 w-20">
+	<div class="mr-2.5 w-40">
 		{#if predicate.column}
 			{#if predicate.column.dataType === MetadataType.BOOLEAN}
 				<Svelecte
@@ -116,7 +116,8 @@
 						inverseOperationMap[Operation.DIFFERENT],
 						inverseOperationMap[Operation.LIKE],
 						inverseOperationMap[Operation.ILIKE],
-						inverseOperationMap[Operation.REGEX]
+						inverseOperationMap[Operation.REGEX],
+						inverseOperationMap[Operation.NOT_REGEX]
 					]}
 				/>
 			{/if}

--- a/frontend/src/lib/components/popups/SlicePopup.svelte
+++ b/frontend/src/lib/components/popups/SlicePopup.svelte
@@ -61,7 +61,10 @@
 					) {
 						return false;
 					}
-					if (predicate.operation === Operation.REGEX) {
+					if (
+						predicate.operation === Operation.REGEX ||
+						predicate.operation === Operation.NOT_REGEX
+					) {
 						try {
 							new RegExp(String(predicate.value));
 						} catch (e) {

--- a/frontend/src/lib/util/util.ts
+++ b/frontend/src/lib/util/util.ts
@@ -126,6 +126,8 @@ export function getOperation(representation: string) {
 			return Operation.ILIKE;
 		case 'REGEX':
 			return Operation.REGEX;
+		case 'NOT_REGEX':
+			return Operation.NOT_REGEX;
 		default:
 			return Operation.EQUAL;
 	}
@@ -140,7 +142,8 @@ export const inverseOperationMap = {
 	[Operation.LTE]: '<=',
 	[Operation.LIKE]: 'LIKE',
 	[Operation.ILIKE]: 'ILIKE',
-	[Operation.REGEX]: 'REGEX'
+	[Operation.REGEX]: 'REGEX',
+	[Operation.NOT_REGEX]: 'NOT_REGEX'
 };
 
 export function shortenNumber(num: number, digits: number) {

--- a/frontend/src/lib/zenoapi/models/Operation.ts
+++ b/frontend/src/lib/zenoapi/models/Operation.ts
@@ -26,5 +26,6 @@ export enum Operation {
 	GTE = 'GTE',
 	LIKE = 'LIKE',
 	ILIKE = 'ILIKE',
-	REGEX = 'REGEX'
+	REGEX = 'REGEX',
+	NOT_REGEX = 'NOT_REGEX'
 }


### PR DESCRIPTION
# Description

Adds a `NOT_REGEX` Operation to filter predicates, which corresponds to `!~` in Postgres (see [this](https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-POSIX-REGEXP)).
