### PR TITLE
fix: unrequire data in view schema

### DIFF
--- a/frontend/src/lib/instance-views/schema.json
+++ b/frontend/src/lib/instance-views/schema.json
@@ -162,7 +162,6 @@
 					"type": "string"
 				}
 			},
-			"required": ["data"],
 			"type": "object"
 		},
 		"ViewType": {

--- a/frontend/src/lib/instance-views/schema.ts
+++ b/frontend/src/lib/instance-views/schema.ts
@@ -67,7 +67,7 @@ export interface SeparatedValues extends View {
 }
 
 export interface ViewSchema {
-	data: ViewUnion;
+	data?: ViewUnion;
 	label?: ViewUnion;
 	output?: ViewUnion;
 	displayType?: DisplayType;


### PR DESCRIPTION
# Description

I ran into this use case when I wanted to only visualize the output of a model without any data.
