### PR TITLE
fix: correct diff comparison and add boolean comparison with three st…

### DIFF
--- a/backend/zeno_backend/database/select.py
+++ b/backend/zeno_backend/database/select.py
@@ -1847,8 +1847,13 @@ async def table_data_paginated(
                 sql.Identifier(req.diff_column_1.id),
                 sql.Identifier(req.diff_column_2.id),
             )
+        elif req.diff_column_1.data_type == MetadataType.BOOLEAN:
+            diff_sql = sql.SQL(", {}::int - {}::int AS diff").format(
+                sql.Identifier(req.diff_column_1.id),
+                sql.Identifier(req.diff_column_2.id),
+            )
         else:
-            diff_sql = sql.SQL(", {} = {} AS diff").format(
+            diff_sql = sql.SQL(", {} != {} AS diff").format(
                 sql.Identifier(req.diff_column_1.id),
                 sql.Identifier(req.diff_column_2.id),
             )


### PR DESCRIPTION
…ates

# Description

fix ZEN-428

For boolean columns this returns -1 if a is false and b is true, 0 if both are the same, and 1 if a is true and b is false.

This makes it possible to sort by model differences where one wants to find out if a better than b or b better than a.
