### PR TITLE
fix: gracefully fail charts if columns have changed

### DIFF
--- a/backend/zeno_backend/classes/chart.py
+++ b/backend/zeno_backend/classes/chart.py
@@ -159,7 +159,6 @@ class Chart(CamelModel):
         type (ChartType): the type of the chart.
         parameters (XCParameters | TableParameters | BeeswarmParameters |
             RadarParameters | HeatmapParameters): the parameters of the chart.
-        data (str): the JSON string data of the chart.
     """
 
     id: int
@@ -173,7 +172,6 @@ class Chart(CamelModel):
         | RadarParameters
         | HeatmapParameters
     )
-    data: str | None = None
 
 
 class ParametersEncoder(json.JSONEncoder):

--- a/backend/zeno_backend/database/insert.py
+++ b/backend/zeno_backend/database/insert.py
@@ -25,7 +25,6 @@ from zeno_backend.classes.tag import Tag
 from zeno_backend.classes.user import Author, Organization, User
 from zeno_backend.database.database import db_pool
 from zeno_backend.database.util import hash_api_key, resolve_metadata_type
-from zeno_backend.processing.chart import calculate_chart_data
 
 
 async def api_key(user: User) -> str | None:
@@ -704,18 +703,15 @@ async def chart(project: str, chart: Chart) -> int | None:
     Returns:
         int | None: the id of the newly created chart.
     """
-    chart_data = await calculate_chart_data(chart, project)
-
     async with db_pool.connection() as conn:
         async with conn.cursor() as cur:
             await cur.execute(
-                "INSERT INTO charts (name, type, parameters, data, project_uuid) "
-                "VALUES (%s,%s,%s,%s,%s) RETURNING id;",
+                "INSERT INTO charts (name, type, parameters, project_uuid) "
+                "VALUES (%s,%s,%s,%s) RETURNING id;",
                 [
                     chart.name,
                     chart.type,
                     json.dumps(chart.parameters, cls=ParametersEncoder),
-                    chart_data,
                     project,
                 ],
             )

--- a/backend/zeno_backend/database/update.py
+++ b/backend/zeno_backend/database/update.py
@@ -13,7 +13,6 @@ from zeno_backend.classes.slice import Slice
 from zeno_backend.classes.tag import Tag
 from zeno_backend.classes.user import Author, Organization, User
 from zeno_backend.database.database import db_pool
-from zeno_backend.processing.chart import calculate_chart_data
 
 
 async def folder(folder: Folder, project: str):
@@ -60,25 +59,20 @@ async def chart(chart: Chart, project: str):
         chart (Chart): the chart data to use for the update.
         project (str): the project the user is currently working with.
     """
-    chart_data = await calculate_chart_data(chart, project)
-
     async with db_pool.connection() as conn:
         async with conn.cursor() as cur:
             await cur.execute(
                 "UPDATE charts SET project_uuid = %s, name = %s, type = %s, "
-                "parameters = %s, data = %s, updated_at = CURRENT_TIMESTAMP "
+                "parameters = %s, data = NULL, updated_at = CURRENT_TIMESTAMP "
                 "WHERE id = %s;",
                 [
                     project,
                     chart.name,
                     chart.type,
                     json.dumps(chart.parameters, cls=ParametersEncoder),
-                    chart_data,
                     chart.id,
                 ],
             )
-
-    return chart_data
 
 
 async def chart_data(chart_id: int, data: str):

--- a/backend/zeno_backend/processing/filtering.py
+++ b/backend/zeno_backend/processing/filtering.py
@@ -87,7 +87,7 @@ async def filter_to_sql(
                 raise HTTPException(
                     status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                     detail=f"Could not find column: {f.column.name} "
-                    "for model {f.column.model}.",
+                    f"for model {f.column.model}.",
                 )
             filt = (
                 filt

--- a/frontend/src/lib/components/report/elements/ChartElement.svelte
+++ b/frontend/src/lib/components/report/elements/ChartElement.svelte
@@ -1,22 +1,29 @@
 <script lang="ts">
 	import { chartMap } from '$lib/util/charts';
-	import { ChartType, type Chart } from '$lib/zenoapi';
+	import { ChartType, ZenoService, type Chart } from '$lib/zenoapi';
+	import { getContext } from 'svelte';
 
 	export let chart: Chart;
 	export let width: number;
+
+	const zenoClient = getContext('zenoClient') as ZenoService;
 </script>
 
 <div class="w-full">
 	<h3 class="text-lg font-semibold">{chart.name}</h3>
-	{#if chart.data}
+	{#await zenoClient.getChartData(chart.projectUuid, chart.id) then data}
 		<div class="text-center">
 			<svelte:component
 				this={chartMap[chart.type]}
 				{chart}
 				{width}
-				data={JSON.parse(chart.data)}
+				data={JSON.parse(data)}
 				height={chart.type == ChartType.RADAR ? 600 : 400}
 			/>
 		</div>
-	{/if}
+	{:catch error}
+		<p class="ml-4 mt-4 font-semibold text-error">
+			Chart data could not be loaded: {error.message}
+		</p>
+	{/await}
 </div>

--- a/frontend/src/lib/zenoapi/models/Chart.ts
+++ b/frontend/src/lib/zenoapi/models/Chart.ts
@@ -20,7 +20,6 @@ import type { XCParameters } from './XCParameters';
  * type (ChartType): the type of the chart.
  * parameters (XCParameters | TableParameters | BeeswarmParameters |
  * RadarParameters | HeatmapParameters): the parameters of the chart.
- * data (str): the JSON string data of the chart.
  */
 export type Chart = {
 	id: number;
@@ -33,5 +32,4 @@ export type Chart = {
 		| BeeswarmParameters
 		| RadarParameters
 		| HeatmapParameters;
-	data?: string | null;
 };

--- a/frontend/src/lib/zenoapi/models/Operation.ts
+++ b/frontend/src/lib/zenoapi/models/Operation.ts
@@ -16,6 +16,7 @@
  * LIKE: like.
  * ILIKE: ilike.
  * REGEX: regex.
+ * NOT_REGEX: not matching regex.
  */
 export enum Operation {
 	EQUAL = 'EQUAL',

--- a/frontend/src/lib/zenoapi/services/ZenoService.ts
+++ b/frontend/src/lib/zenoapi/services/ZenoService.ts
@@ -281,7 +281,7 @@ export class ZenoService {
 	 * HTTPException: error if the chart could not be fetched.
 	 *
 	 * Returns:
-	 * ChartResponse: chart spec and data.
+	 * ChartResponse: chart spec.
 	 * @param chartId
 	 * @param projectUuid
 	 * @returns Chart Successful Response
@@ -296,6 +296,72 @@ export class ZenoService {
 			},
 			query: {
 				project_uuid: projectUuid
+			},
+			errors: {
+				422: `Validation Error`
+			}
+		});
+	}
+
+	/**
+	 * Get Chart Data
+	 * Get a chart's data.
+	 *
+	 * Args:
+	 * project_uuid (str): UUID of the project to get a chart from.
+	 * chart_id (int): id of the chart to be fetched.
+	 * request (Request): http request to get user information from.
+	 *
+	 * Raises:
+	 * HTTPException: error if the chart could not be fetched.
+	 *
+	 * Returns:
+	 * str: chart data.
+	 * @param projectUuid
+	 * @param chartId
+	 * @returns string Successful Response
+	 * @throws ApiError
+	 */
+	public getChartData(projectUuid: any, chartId: number): CancelablePromise<string> {
+		return this.httpRequest.request({
+			method: 'GET',
+			url: '/chart-data/{project_uuid}/{chart_id}',
+			path: {
+				project_uuid: projectUuid,
+				chart_id: chartId
+			},
+			errors: {
+				422: `Validation Error`
+			}
+		});
+	}
+
+	/**
+	 * Get Chart Data
+	 * Get a chart's data.
+	 *
+	 * Args:
+	 * project_uuid (str): UUID of the project to get a chart from.
+	 * chart_id (int): id of the chart to be fetched.
+	 * request (Request): http request to get user information from.
+	 *
+	 * Raises:
+	 * HTTPException: error if the chart could not be fetched.
+	 *
+	 * Returns:
+	 * str: chart data.
+	 * @param projectUuid
+	 * @param chartId
+	 * @returns string Successful Response
+	 * @throws ApiError
+	 */
+	public getChartData1(projectUuid: any, chartId: number): CancelablePromise<string> {
+		return this.httpRequest.request({
+			method: 'GET',
+			url: '/chart-data/{project_uuid}/{chart_id}',
+			path: {
+				project_uuid: projectUuid,
+				chart_id: chartId
 			},
 			errors: {
 				422: `Validation Error`

--- a/frontend/src/routes/(app)/project/[uuid]/[name]/chart/[chartIndex=integer]/+page.svelte
+++ b/frontend/src/routes/(app)/project/[uuid]/[name]/chart/[chartIndex=integer]/+page.svelte
@@ -18,8 +18,8 @@
 	let mounted = false;
 	let isChartEdit: boolean | undefined;
 	let chart = data.chart;
-	let chartData = chart.data ? JSON.parse(chart.data) : undefined;
 	let updatingData = false;
+	let chartDataRequest = zenoClient.getChartData(chart.projectUuid, chart.id);
 
 	$: updateEditUrl(isChartEdit);
 	$: updateChart(chart);
@@ -39,8 +39,8 @@
 	function updateChart(chart: Chart) {
 		updatingData = true;
 		if (mounted && $project && $project.editor && browser) {
-			zenoClient.updateChart($project.uuid, chart).then((d) => {
-				chartData = JSON.parse(d);
+			zenoClient.updateChart($project.uuid, chart).then(() => {
+				chartDataRequest = zenoClient.getChartData(chart.projectUuid, chart.id);
 				updatingData = false;
 			});
 		} else {
@@ -66,11 +66,13 @@
 	{:else}
 		<ViewHeader bind:isChartEdit />
 	{/if}
-	{#if chartData}
-		<div class={`flex h-full w-full flex-col overflow-auto pl-2`}>
-			<ChartContainer chartName={chart.name} loading={updatingData}>
-				<svelte:component this={chartMap[chart.type]} {chart} data={chartData} width={900} />
-			</ChartContainer>
-		</div>
-	{/if}
+	{#await chartDataRequest then data}
+		<ChartContainer chartName={chart.name} loading={updatingData}>
+			<svelte:component this={chartMap[chart.type]} {chart} data={JSON.parse(data)} width={900} />
+		</ChartContainer>
+	{:catch error}
+		<p class="ml-4 mt-4 font-semibold text-error">
+			Chart data could not be loaded: {error.message}
+		</p>
+	{/await}
 </div>


### PR DESCRIPTION
# Description

fix ZEN-414

This disentangles the fetching of chart data from the chart. The reason behind this is that fetching chart data has some failure cases (e.g. a column for a slice filter does not exist anymore) that should not break charts altogether. It should still be possible to change the chart spec. Furthermore, this adds an error message if the chart data could not be loaded.