### PR TITLE
fix: prevent project value overwrite

### DIFF
--- a/backend/zeno_backend/classes/project.py
+++ b/backend/zeno_backend/classes/project.py
@@ -27,13 +27,13 @@ class Project(CamelModel):
 
     uuid: str
     name: str
-    description: str = ""
+    description: str | None = ""
     metrics: list[Metric] = []
     owner_name: str
     view: str
-    editor: bool
-    samples_per_page: int = 30
-    public: bool = False
+    editor: bool = False
+    samples_per_page: int | None = 30
+    public: bool | None = False
     created_at: str = ""
     updated_at: str = ""
 

--- a/backend/zeno_backend/database/insert.py
+++ b/backend/zeno_backend/database/insert.py
@@ -73,6 +73,7 @@ async def project(project_config: Project, owner_id: int):
         Exception: something went wrong in the process of creating the new project in
             the database.
     """
+    default_project = Project(uuid="", name="", owner_name="", view="")
     async with db_pool.connection() as conn:
         async with conn.cursor() as cur:
             await cur.execute(
@@ -84,9 +85,15 @@ async def project(project_config: Project, owner_id: int):
                     project_config.name,
                     owner_id,
                     project_config.view,
-                    project_config.samples_per_page,
-                    project_config.public,
-                    project_config.description,
+                    default_project.samples_per_page
+                    if project_config.samples_per_page is None
+                    else project_config.samples_per_page,
+                    default_project.public
+                    if project_config.public is None
+                    else project_config.public,
+                    default_project.description
+                    if project_config.description is None
+                    else project_config.description,
                 ],
             )
             await cur.execute(


### PR DESCRIPTION
# Description

Does not automatically overwrite project fields:
`public`, `description`, and `samples_per_page`
when reuploading.

Needs to be merged with: https://github.com/zeno-ml/zeno-client/pull/49