### PR TITLE
fix: prevents explore from crashing when histograms could not be rend…

### DIFF
--- a/backend/zeno_backend/processing/histogram_processing.py
+++ b/backend/zeno_backend/processing/histogram_processing.py
@@ -151,10 +151,9 @@ async def histogram_metric_and_count(
                     [request.metric.columns[0], request.model],
                 )
                 metric_col_id = await db.fetchone()
-                if metric_col_id is None:
-                    return []
-                metric_col_type = metric_col_id[1]
-                metric_col_id = metric_col_id[0]
+                if metric_col_id is not None:
+                    metric_col_type = metric_col_id[1]
+                    metric_col_id = metric_col_id[0]
 
             if col.data_type == MetadataType.NOMINAL:
                 if calculate_histograms and metric_col_id is not None:
@@ -182,7 +181,7 @@ async def histogram_metric_and_count(
 
                 await db.execute(statement)
                 db_res = await db.fetchall()
-                if calculate_histograms:
+                if calculate_histograms and metric_col_id is not None:
                     results_map = {r[0]: (r[1], r[2]) for r in db_res}
                     return [
                         HistogramBucket(
@@ -255,7 +254,7 @@ async def histogram_metric_and_count(
                 await db.execute(statement)
                 db_res = await db.fetchall()
 
-                if calculate_histograms:
+                if calculate_histograms and metric_col_id is not None:
                     results_map = {
                         int(r[0]): (r[1], r[2]) for r in db_res if r[0] is not None
                     }
@@ -313,7 +312,7 @@ async def histogram_metric_and_count(
 
                 true_res = [r for r in res if r[0] == 0]
                 false_res = [r for r in res if r[0] == 1]
-                if calculate_histograms:
+                if calculate_histograms and metric_col_id is not None:
                     return [
                         HistogramBucket(
                             bucket=True,

--- a/frontend/src/lib/components/metadata/Histograms.svelte
+++ b/frontend/src/lib/components/metadata/Histograms.svelte
@@ -138,7 +138,7 @@
 		.filter((c) => (c.model === undefined || c.model === null || c.model === $model) && histogramColumnsBaseFilter(c))
 		.sort(reverseColumnSort) as col (col.id)}
 		{@const hist = metadataHistograms.get(col.id)}
-		{#if hist}
+		{#if hist && hist.length > 0}
 			<MetadataCell {col} histogram={hist} />
 		{/if}
 	{/each}


### PR DESCRIPTION
…ered

# Description

This fixes two issues:
1. If an empty list is returned for a histogram, explore became unresponsive. This has been fixed by just not rendering the broken histogram.
2. If a metric was defined on a non-existent column, our histogram calculation returned an empty list of buckets. This has been changed so that the metric is ignored instead.