### PR TITLE
fix: don't show ouptut in compare

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -31,7 +31,7 @@
 			},
 			"devDependencies": {
 				"@formkit/auto-animate": "^0.8.1",
-				"@playwright/test": "^1.41.2",
+				"@playwright/test": "^1.48.0",
 				"@smui/button": "7.0.0-beta.16",
 				"@smui/checkbox": "7.0.0-beta.16",
 				"@smui/chips": "7.0.0-beta.16",
@@ -1565,18 +1565,18 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.41.2",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.41.2.tgz",
-			"integrity": "sha512-qQB9h7KbibJzrDpkXkYvsmiDJK14FULCCZgEcoe2AvFAS64oCirWTwzTlAYEbKaRxWs5TFesE1Na6izMv3HfGg==",
+			"version": "1.49.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
+			"integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
 			"dev": true,
 			"dependencies": {
-				"playwright": "1.41.2"
+				"playwright": "1.49.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@polka/url": {
@@ -5664,33 +5664,33 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.41.2",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.41.2.tgz",
-			"integrity": "sha512-v0bOa6H2GJChDL8pAeLa/LZC4feoAMbSQm1/jF/ySsWWoaNItvrMP7GEkvEEFyCTUYKMxjQKaTSg5up7nR6/8A==",
+			"version": "1.49.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
+			"integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
 			"dev": true,
 			"dependencies": {
-				"playwright-core": "1.41.2"
+				"playwright-core": "1.49.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=18"
 			},
 			"optionalDependencies": {
 				"fsevents": "2.3.2"
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.41.2",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.41.2.tgz",
-			"integrity": "sha512-VaTvwCA4Y8kxEe+kfm2+uUUw5Lubf38RxF7FpBxLPmGe5sdNkSg5e3ChEigaGrX7qdqT3pt2m/98LiyvU2x6CA==",
+			"version": "1.49.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
+			"integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
 			"dev": true,
 			"bin": {
 				"playwright-core": "cli.js"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=18"
 			}
 		},
 		"node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
 	},
 	"devDependencies": {
 		"@formkit/auto-animate": "^0.8.1",
-		"@playwright/test": "^1.41.2",
+		"@playwright/test": "^1.48.0",
 		"@smui/button": "7.0.0-beta.16",
 		"@smui/checkbox": "7.0.0-beta.16",
 		"@smui/chips": "7.0.0-beta.16",

--- a/frontend/src/lib/components/instances/ComparisonView.svelte
+++ b/frontend/src/lib/components/instances/ComparisonView.svelte
@@ -271,10 +271,12 @@
 			{#each table as tableContent (`${tableContent[idColumn]}_${modelAColumn}_${modelBColumn}`)}
 				<tr>
 					<td class="p-3 align-baseline">
-						<p class="mb-2">
-							<span class="text-grey-dark">{$comparisonColumn?.name}:</span>
-							{modelValueAndDiff($model, tableContent)}
-						</p>
+						{#if $comparisonColumn?.name !== 'output'}
+							<p class="mb-2">
+								<span class="text-grey-dark">{$comparisonColumn?.name}:</span>
+								{modelValueAndDiff($model, tableContent)}
+							</p>
+						{/if}
 						<InstanceView
 							view={$project.view}
 							{idColumn}


### PR DESCRIPTION
If output is selected, it does not really make sense to show it since the instance view is shown right below anyway.
